### PR TITLE
Update AGP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ google-services.json
 
 # Android Profiling
 *.hprof
+lint.xml

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,7 @@
 @file:Suppress("SpellCheckingInspection")
 
+import de.fayard.refreshVersions.core.versionFor
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -43,8 +45,7 @@ android {
     }
 
     composeOptions {
-        // TODO: Extract the version from versions.properties using `versionFor()`.
-        kotlinCompilerExtensionVersion = "1.1.1"
+        kotlinCompilerExtensionVersion = versionFor(AndroidX.compose.compiler)
     }
 
     packagingOptions {

--- a/versions.properties
+++ b/versions.properties
@@ -71,13 +71,6 @@ version.androidx.core=1.7.0
 ##        # available=1.9.0-alpha01
 ##        # available=1.9.0-alpha02
 
-## unused
-version.androidx.fragment=1.4.1
-##            # available=1.5.0-alpha01
-##            # available=1.5.0-alpha02
-##            # available=1.5.0-alpha03
-##            # available=1.5.0-alpha04
-
 version.androidx.navigation-compose=2.4.1
 ##                      # available=2.5.0-alpha01
 ##                      # available=2.5.0-alpha02

--- a/versions.properties
+++ b/versions.properties
@@ -36,6 +36,7 @@ version.androidx.activity=1.4.0
 ##            # available=1.5.0-alpha04
 ##            # available=1.6.0-alpha01
 
+# TODO: Keep track of https://github.com/jmfayard/refreshVersions/issues/511.
 ## unused
 version.androidx.compose.compiler=1.1.1
 

--- a/versions.properties
+++ b/versions.properties
@@ -7,9 +7,7 @@
 #### suppress inspection "SpellCheckingInspection" for whole file
 #### suppress inspection "UnusedProperty" for whole file
 
-plugin.android=7.1.0
-## # available=7.1.1
-## # available=7.1.2
+plugin.android=7.1.2
 ## # available=7.2.0-alpha01
 ## # available=7.2.0-alpha02
 ## # available=7.2.0-alpha03
@@ -69,9 +67,11 @@ version.androidx.core=1.7.0
 ##        # available=1.8.0-alpha03
 ##        # available=1.8.0-alpha04
 ##        # available=1.8.0-alpha05
+##        # available=1.8.0-alpha06
 ##        # available=1.9.0-alpha01
 ##        # available=1.9.0-alpha02
 
+## unused
 version.androidx.fragment=1.4.1
 ##            # available=1.5.0-alpha01
 ##            # available=1.5.0-alpha02


### PR DESCRIPTION
Updated the [Android Gradle Plugin](https://developer.android.com/studio/releases/gradle-plugin).

**Summary of changes:**
1. [Updated AGP to 7.1.2](https://developer.android.com/studio/releases/gradle-plugin#7-1-0).
2. Updated `.gitignore`.
3. Removed unused version added in #7.
4. Resolved [refreshVersions API](https://jmfayard.github.io/refreshVersions/add-dependencies/#get-the-version-from-anywhere) usage `TODO`.