### PR TITLE
Updated Apollo Kotlin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,15 +59,6 @@ apollo {
     packageName.set("com.imashnake.animite")
 }
 
-// TODO:
-//  This is a temporary workaround, remove this once Apollo Kotlin 3.1.1 is out, see:
-//  https://github.com/jmfayard/refreshVersions/issues/507.
-tasks.configureEach {
-    if (name == "checkApolloVersions") {
-        enabled = false
-    }
-}
-
 dependencies {
     // AndroidX
     implementation(AndroidX.activity.compose)

--- a/versions.properties
+++ b/versions.properties
@@ -27,7 +27,7 @@ plugin.android=7.1.2
 ## # available=7.3.0-alpha06
 ## # available=7.3.0-alpha07
 
-plugin.com.apollographql.apollo3=3.1.0
+plugin.com.apollographql.apollo3=3.2.0
 
 version.androidx.activity=1.4.0
 ##            # available=1.5.0-alpha01
@@ -101,7 +101,7 @@ version.androidx.test.ext.junit=1.1.3
 ##                  # available=1.1.4-alpha04
 ##                  # available=1.1.4-alpha05
 
-version.apollo.runtime=3.1.0
+version.apollo.runtime=3.2.0
 
 version.junit.junit=4.13.2
 


### PR DESCRIPTION
Went through [release notes](https://github.com/apollographql/apollo-kotlin/releases/tag/v3.2.0) and updated Apollo Kotlin to 3.2.0.

**Summary of changes:**
1. Updated Apollo Kotlin to 3.2.0.
2. Resolved `TODO`: `refreshVersions` [error](https://github.com/jmfayard/refreshVersions/issues/507) was [fixed](https://github.com/apollographql/apollo-kotlin/pull/3898) in this release.