### PR TITLE
Refactor Home path

### DIFF
--- a/app/src/main/java/com/imashnake/animite/ui/elements/home/Home.kt
+++ b/app/src/main/java/com/imashnake/animite/ui/elements/home/Home.kt
@@ -34,11 +34,11 @@ fun Home(
 
     when {
         trendingNowAnimeList != null && popularThisSeasonAnimeList != null -> {
-            // TODO: `padding(vertical = 12.dp)` doesn't work for whatever reason. Get it to work.
             Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(Backdrop)
+                    .padding(vertical = 12.dp)
             ) {
                 Spacer(modifier = Modifier.size(24.dp))
 

--- a/app/src/main/java/com/imashnake/animite/ui/elements/home/Home.kt
+++ b/app/src/main/java/com/imashnake/animite/ui/elements/home/Home.kt
@@ -34,6 +34,7 @@ fun Home(
 
     when {
         trendingNowAnimeList != null && popularThisSeasonAnimeList != null -> {
+            // TODO: `padding(vertical = 12.dp)` doesn't work for whatever reason. Get it to work.
             Column(
                 modifier = Modifier
                     .fillMaxSize()

--- a/app/src/main/java/com/imashnake/animite/ui/elements/home/Home.kt
+++ b/app/src/main/java/com/imashnake/animite/ui/elements/home/Home.kt
@@ -38,7 +38,6 @@ fun Home(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(Backdrop)
-                    .padding(vertical = 12.dp)
             ) {
                 Spacer(modifier = Modifier.size(24.dp))
 

--- a/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmall.kt
+++ b/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmall.kt
@@ -34,7 +34,7 @@ fun MediaSmall(image: String?, anime: String?) {
         onClick = { },
         modifier = Modifier
             .wrapContentHeight()
-            .width((115 + 12 + 12).dp),
+            .width(115.dp),
         containerColor = Card,
         shape = mediaSmallShape
     ) {

--- a/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmall.kt
+++ b/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmall.kt
@@ -34,8 +34,7 @@ fun MediaSmall(image: String?, anime: String?) {
         onClick = { },
         modifier = Modifier
             .wrapContentHeight()
-            .width((115 + 12 + 12).dp)
-            .padding(start = 12.dp, end = 12.dp),
+            .width((115 + 12 + 12).dp),
         containerColor = Card,
         shape = mediaSmallShape
     ) {

--- a/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmallRow.kt
+++ b/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmallRow.kt
@@ -31,7 +31,7 @@ fun MediaSmallRow(mediaList: List<Any>) {
 @Composable
 fun TrendingNowAnimeSmallRow(mediaList: List<TrendingNowQuery.Medium?>) {
     LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(24.dp),
         contentPadding = PaddingValues(start = 24.dp, end = 24.dp)
     ) {
         items(mediaList) { media ->

--- a/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmallRow.kt
+++ b/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmallRow.kt
@@ -55,7 +55,7 @@ fun TrendingNowAnimeSmallRow(mediaList: List<TrendingNowQuery.Medium?>) {
 fun PopularAnimeThisSeasonSmallRow(mediaList: List<PopularThisSeasonQuery.Medium?>) {
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(24.dp),
-        contentPadding = PaddingValues(start = 12.dp, end = 12.dp)
+        contentPadding = PaddingValues(start = 24.dp, end = 24.dp)
     ) {
         items(mediaList) { media ->
             MediaSmall(

--- a/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmallRow.kt
+++ b/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmallRow.kt
@@ -54,7 +54,7 @@ fun TrendingNowAnimeSmallRow(mediaList: List<TrendingNowQuery.Medium?>) {
 @Composable
 fun PopularAnimeThisSeasonSmallRow(mediaList: List<PopularThisSeasonQuery.Medium?>) {
     LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(24.dp),
         contentPadding = PaddingValues(start = 12.dp, end = 12.dp)
     ) {
         items(mediaList) { media ->

--- a/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmallRow.kt
+++ b/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmallRow.kt
@@ -1,11 +1,11 @@
 package com.imashnake.animite.ui.elements.home
 
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.imashnake.animite.PopularThisSeasonQuery
@@ -31,7 +31,8 @@ fun MediaSmallRow(mediaList: List<Any>) {
 @Composable
 fun TrendingNowAnimeSmallRow(mediaList: List<TrendingNowQuery.Medium?>) {
     LazyRow(
-        modifier = Modifier.padding(start = 12.dp)
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(start = 12.dp, end = 12.dp)
     ) {
         items(mediaList) { media ->
             MediaSmall(
@@ -53,7 +54,8 @@ fun TrendingNowAnimeSmallRow(mediaList: List<TrendingNowQuery.Medium?>) {
 @Composable
 fun PopularAnimeThisSeasonSmallRow(mediaList: List<PopularThisSeasonQuery.Medium?>) {
     LazyRow(
-        modifier = Modifier.padding(start = 12.dp)
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(start = 12.dp, end = 12.dp)
     ) {
         items(mediaList) { media ->
             MediaSmall(

--- a/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmallRow.kt
+++ b/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmallRow.kt
@@ -32,7 +32,7 @@ fun MediaSmallRow(mediaList: List<Any>) {
 fun TrendingNowAnimeSmallRow(mediaList: List<TrendingNowQuery.Medium?>) {
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        contentPadding = PaddingValues(start = 12.dp, end = 12.dp)
+        contentPadding = PaddingValues(start = 24.dp, end = 24.dp)
     ) {
         items(mediaList) { media ->
             MediaSmall(


### PR DESCRIPTION
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

**Summary of changes:**
1. Applied vertical padding (`12.dp`) in the Home path.
2. Implemented [`horizontalArrangement`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/Arrangement) in `MediaSmallRow`'s `LazyRow`, this replaces the padding modifier in the `MediaSmall` card.
3. Changed the padding modifier in `MediaSmallRow`'s `LazyRow` to `contentPadding`, it is like [`clipToPadding`](https://stackoverflow.com/questions/66435811/jetpack-compose-cliptopadding) in xml.

**Tested changes:**
The layout of the Home path is the same.

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
