### PR TITLE
Update Compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,8 +47,7 @@ android {
     }
 
     composeOptions {
-        // TODO: Use version catalogs for this once Compose is updated and "bundled".
-        kotlinCompilerExtensionVersion = "1.1.1"
+        kotlinCompilerExtensionVersion = deps.versions.compose.get()
     }
 
     packagingOptions {

--- a/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmall.kt
+++ b/app/src/main/java/com/imashnake/animite/ui/elements/home/MediaSmall.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults.cardColors
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,11 +32,10 @@ import com.imashnake.animite.ui.theme.mediaSmallShape
 @Composable
 fun MediaSmall(image: String?, anime: String?) {
     Card(
-        onClick = { },
         modifier = Modifier
             .wrapContentHeight()
             .width(115.dp),
-        containerColor = Card,
+        colors = cardColors(containerColor = Card),
         shape = mediaSmallShape
     ) {
         AsyncImage(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ compose = "1.1.1"
 composeFoundation = "1.2.0-alpha08"
 composeMaterial3 = "1.0.0-alpha07"
 composeRuntime = "1.2.0-alpha05"
+composeMaterial3 = "1.0.0-alpha11"
 
 [plugins]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,7 @@
 # Compose
 # https://developer.android.com/jetpack/androidx/releases/compose.
 compose = "1.2.0-beta01"
-composeFoundation = "1.2.0-beta01"
 composeMaterial3 = "1.0.0-alpha11"
-composeRuntime = "1.2.0-beta01"
 
 [plugins]
 
@@ -26,11 +24,10 @@ androidx-test-junit = "androidx.test.ext:junit:1.1.3"
 androidx-test-espressoCore = "androidx.test.espresso:espresso-core:3.4.0"
 
 # Compose
-# TODO: Update and "bundle" dependencies.
-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "composeFoundation" }
+compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "compose" }
 compose-material = { group = "androidx.compose.material", name = "material", version.ref = "compose" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "composeMaterial3" }
-compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "composeRuntime" }
+compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "compose" }
 compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
 compose-ui-toolingPreview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "compose" }
 compose-test-ui-testJunit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "compose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,16 @@
 [versions]
 
-compose = "1.1.1"
-composeFoundation = "1.2.0-alpha08"
-composeMaterial3 = "1.0.0-alpha07"
-composeRuntime = "1.2.0-alpha05"
+# Compose
+# https://developer.android.com/jetpack/androidx/releases/compose.
+compose = "1.2.0-beta01"
+composeFoundation = "1.2.0-beta01"
 composeMaterial3 = "1.0.0-alpha11"
+composeRuntime = "1.2.0-beta01"
 
 [plugins]
 
 agp = { id = "com.android.application", version = "7.1.3" }
-kotlin = { id = "org.jetbrains.kotlin.android", version = "1.6.10" }
+kotlin = { id = "org.jetbrains.kotlin.android", version = "1.6.21" }
 apolloKotlin = { id = "com.apollographql.apollo3", version = "3.2.2" }
 hilt = { id = "com.google.dagger.hilt.android", version = "2.41" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,3 +1,10 @@
+[versions]
+
+compose = "1.1.1"
+composeFoundation = "1.2.0-alpha08"
+composeMaterial3 = "1.0.0-alpha07"
+composeRuntime = "1.2.0-alpha05"
+
 [plugins]
 
 agp = { id = "com.android.application", version = "7.1.3" }
@@ -18,14 +25,14 @@ androidx-test-espressoCore = "androidx.test.espresso:espresso-core:3.4.0"
 
 # Compose
 # TODO: Update and "bundle" dependencies.
-compose-foundation = "androidx.compose.foundation:foundation:1.2.0-alpha08"
-compose-material = "androidx.compose.material:material:1.1.1"
-compose-material3 = "androidx.compose.material3:material3:1.0.0-alpha07"
-compose-runtime = "androidx.compose.runtime:runtime:1.2.0-alpha05"
-compose-ui = "androidx.compose.ui:ui:1.1.1"
-compose-ui-toolingPreview = "androidx.compose.ui:ui-tooling-preview:1.1.1"
-compose-test-ui-testJunit4 = "androidx.compose.ui:ui-test-junit4:1.1.1"
-compose-test-ui-tooling = "androidx.compose.ui:ui-tooling:1.1.1"
+compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "composeFoundation" }
+compose-material = { group = "androidx.compose.material", name = "material", version.ref = "compose" }
+compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "composeMaterial3" }
+compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "composeRuntime" }
+compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
+compose-ui-toolingPreview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "compose" }
+compose-test-ui-testJunit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "compose" }
+compose-test-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose" }
 
 # Apollo Kotlin
 apolloKotlin-runtime = "com.apollographql.apollo3:apollo-runtime:3.2.2"


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Updated Compose dependencies to [1.2.0-beta01](https://developer.android.com/jetpack/androidx/releases/compose) (except `compose-material3` which is still in alpha; updated to [1.0.0-alpha11](https://developer.android.com/jetpack/androidx/releases/compose-material3#1.0.0-alpha11)).

**Summary of changes:**

1. Created a Compose version reference using the [`version.ref`](https://docs.gradle.org/current/userguide/platforms.html) API.
2. Retrieved version for Compose Compiler from the catalog.
3. Updated `compose-material3` to `1.0.0-alpha11` and made changes according to API changes (`Surface`s are [not clickable anymore](https://android-review.googlesource.com/c/platform/frameworks/support/+/2001771/15/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Card.kt) and [changes to the way `Card`s are colored](https://android-review.googlesource.com/c/platform/frameworks/support/+/2053386/4/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Card.kt)).
4. Updated the rest of the Compose artifacts and [Kotlin to 1.6.21 (this was required)](https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.2.0-beta01).
5. Grouped dependency versions.

**Tested changes:**

App builds (Apparently, gradle doesn't like it when version catalogs don't end with "Libs", as is the case with `deps`; fix this).

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
