### PR TITLE
Replace @Experimental* with OptIn variants

### DIFF
--- a/app/src/main/java/com/imashnake/animite/features/MainActivity.kt
+++ b/app/src/main/java/com/imashnake/animite/features/MainActivity.kt
@@ -13,18 +13,15 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
@@ -44,13 +41,9 @@ import com.ramcosta.composedestinations.animations.defaults.RootNavGraphDefaultA
 import com.ramcosta.composedestinations.animations.rememberAnimatedNavHostEngine
 import dagger.hilt.android.AndroidEntryPoint
 
-@ExperimentalFoundationApi
-@ExperimentalMaterialNavigationApi
-@ExperimentalComposeUiApi
-@ExperimentalAnimationApi
-@ExperimentalMaterial3Api
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalAnimationApi::class, ExperimentalMaterialNavigationApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/com/imashnake/animite/features/home/Home.kt
+++ b/app/src/main/java/com/imashnake/animite/features/home/Home.kt
@@ -1,7 +1,6 @@
 package com.imashnake.animite.features.home
 
 import android.content.res.Configuration
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -19,7 +18,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -46,8 +44,6 @@ import com.ramcosta.composedestinations.annotation.RootNavGraph
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.imashnake.animite.R as Res
 
-@ExperimentalAnimationApi
-@ExperimentalMaterial3Api
 @RootNavGraph(start = true)
 @Destination(style = HomeTransitions::class)
 @Composable

--- a/app/src/main/java/com/imashnake/animite/features/home/HomeTransitions.kt
+++ b/app/src/main/java/com/imashnake/animite/features/home/HomeTransitions.kt
@@ -2,14 +2,12 @@ package com.imashnake.animite.features.home
 
 import androidx.compose.animation.*
 import androidx.compose.animation.core.tween
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.navigation.NavBackStackEntry
 import com.imashnake.animite.features.appDestination
 import com.imashnake.animite.features.destinations.ProfileDestination
 import com.ramcosta.composedestinations.spec.DestinationStyle
 
-@ExperimentalMaterial3Api
-@ExperimentalAnimationApi
+@OptIn(ExperimentalAnimationApi::class)
 object HomeTransitions : DestinationStyle.Animated {
     override fun AnimatedContentScope<NavBackStackEntry>.enterTransition(): EnterTransition? {
         return when (initialState.appDestination()) {

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -68,7 +68,6 @@ import com.imashnake.animite.type.MediaType
 import com.ramcosta.composedestinations.annotation.Destination
 import com.imashnake.animite.R as Res
 
-@ExperimentalMaterial3Api
 @Destination
 @Composable
 fun MediaPage(
@@ -443,7 +442,7 @@ fun Stat(label: String, score: Int, format: (Int) -> String) {
     }
 }
 
-@ExperimentalMaterial3Api
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Genre(genre: String?, color: Color, onClick: () -> Unit) {
     SuggestionChip(

--- a/app/src/main/java/com/imashnake/animite/features/navigationbar/NavigationBar.kt
+++ b/app/src/main/java/com/imashnake/animite/features/navigationbar/NavigationBar.kt
@@ -38,9 +38,6 @@ import com.ramcosta.composedestinations.spec.DirectionDestinationSpec
 import com.imashnake.animite.R as Res
 
 // TODO: Ripple where?
-@ExperimentalComposeUiApi
-@ExperimentalAnimationApi
-@ExperimentalMaterial3Api
 @Composable
 fun NavigationBar(
     navController: NavController
@@ -98,9 +95,7 @@ enum class NavigationBarPaths(
         }
     ),
 
-    @ExperimentalAnimationApi
-    @ExperimentalMaterial3Api
-    Home(
+            Home(
         HomeDestination,
         {
             Icon(
@@ -113,9 +108,7 @@ enum class NavigationBarPaths(
             )
         }
     ),
-    @ExperimentalAnimationApi
-    @ExperimentalMaterial3Api
-    Profile(
+            Profile(
         ProfileDestination,
         {
             Icon(

--- a/app/src/main/java/com/imashnake/animite/features/profile/Profile.kt
+++ b/app/src/main/java/com/imashnake/animite/features/profile/Profile.kt
@@ -12,8 +12,6 @@ import androidx.compose.ui.Modifier
 import com.imashnake.animite.features.ui.ProgressIndicator
 import com.ramcosta.composedestinations.annotation.Destination
 
-@ExperimentalMaterial3Api
-@ExperimentalAnimationApi
 @Destination(style = ProfileTransitions::class)
 @Composable
 fun Profile() {

--- a/app/src/main/java/com/imashnake/animite/features/profile/ProfileTransitions.kt
+++ b/app/src/main/java/com/imashnake/animite/features/profile/ProfileTransitions.kt
@@ -8,8 +8,7 @@ import com.imashnake.animite.features.appDestination
 import com.imashnake.animite.features.destinations.HomeDestination
 import com.ramcosta.composedestinations.spec.DestinationStyle
 
-@ExperimentalAnimationApi
-@ExperimentalMaterial3Api
+@OptIn(ExperimentalAnimationApi::class)
 object ProfileTransitions : DestinationStyle.Animated {
     override fun AnimatedContentScope<NavBackStackEntry>.enterTransition(): EnterTransition? {
         return when (initialState.appDestination()) {

--- a/app/src/main/java/com/imashnake/animite/features/searchbar/SearchBar.kt
+++ b/app/src/main/java/com/imashnake/animite/features/searchbar/SearchBar.kt
@@ -48,10 +48,7 @@ import com.imashnake.animite.R as Res
 // TODO:
 //  - UX concern: This blocks content sometimes!
 //  - `SearchList` goes beyond the status bar.
-@ExperimentalFoundationApi
-@ExperimentalComposeUiApi
-@ExperimentalAnimationApi
-@ExperimentalMaterial3Api
+@OptIn(ExperimentalAnimationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun SearchBar(
     modifier: Modifier,
@@ -114,7 +111,6 @@ fun SearchBar(
     }
 }
 
-@ExperimentalMaterial3Api
 @Composable
 fun CollapsedSearchBar() {
     Row(
@@ -129,8 +125,7 @@ fun CollapsedSearchBar() {
     }
 }
 
-@ExperimentalComposeUiApi
-@ExperimentalMaterial3Api
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun ExpandedSearchBar(viewModel: SearchViewModel = viewModel()) {
     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -205,8 +200,7 @@ fun ExpandedSearchBar(viewModel: SearchViewModel = viewModel()) {
     }
 }
 
-@ExperimentalFoundationApi
-@ExperimentalAnimationApi
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SearchList(
     viewModel: SearchViewModel = viewModel(),
@@ -254,8 +248,6 @@ private fun SearchItem(item: SearchQuery.Medium?, onClick: (Int?) -> Unit, modif
     )
 }
 
-@ExperimentalComposeUiApi
-@ExperimentalMaterial3Api
 @Preview
 @Composable
 fun PreviewSearchBar() {


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Experimental annotations are *propagating*. This leads to cases like MainActivity defining 5+ annotations, which is not fun. By moving to OptIn, not only do we not need to propagate annotations, but our IDE can tell us when they are no longer needed. It's a win-win!

**Summary of changes:**

1. Deleted all @Experimental* annotations
2. Added @OptIn(Experimental*) as needed

**Tested changes:**

The app still runs

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
