### PR TITLE
Fixed `notify-release-created.yaml`

### DIFF
--- a/.github/workflows/notify-release-created.yaml
+++ b/.github/workflows/notify-release-created.yaml
@@ -3,7 +3,7 @@ name: notify-build-debug-complete
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   on-complete:


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Trigger on release created, rather than published.

**Tested changes:**

N/A.

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
