### PR TITLE
Further decouple search elements

### DIFF
--- a/app/src/main/java/com/imashnake/animite/features/MainActivity.kt
+++ b/app/src/main/java/com/imashnake/animite/features/MainActivity.kt
@@ -112,7 +112,7 @@ fun MainScreen(modifier: Modifier = Modifier) {
                 navController.navigate(
                     MediaPageDestination(
                         MediaPageArgs(
-                            id!!,
+                            id,
                             mediaType.rawValue
                         )
                     )

--- a/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFab.kt
+++ b/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFab.kt
@@ -1,0 +1,182 @@
+package com.imashnake.animite.features.searchbar
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.KeyboardArrowRight
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.imashnake.animite.R
+
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalAnimationApi::class)
+@Composable
+fun SearchFab(
+    isExpanded: Boolean,
+    setExpanded: (Boolean) -> Unit,
+    onSearched: (String?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.primary,
+        modifier = modifier,
+        shadowElevation = 20.dp,
+        shape = CircleShape
+    ) {
+        val keyboardController = LocalSoftwareKeyboardController.current
+        AnimatedContent(targetState = isExpanded) { targetExpanded ->
+            if (targetExpanded) {
+                ExpandedSearchBarContent(
+                    collapse = {
+                        setExpanded(false)
+                        onSearched(null)
+                        keyboardController?.hide()
+                    },
+                    clearText = { onSearched(null) },
+                    searchText = { onSearched(it) }
+                )
+            } else {
+                CollapsedSearchBarContent(
+                    expand = { setExpanded(true) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun CollapsedSearchBarContent(
+    expand: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        imageVector = ImageVector.vectorResource(R.drawable.search),
+        contentDescription = stringResource(R.string.search),
+        modifier = modifier
+            .clickable(onClick = expand)
+            .padding(dimensionResource(R.dimen.search_bar_icon_padding)),
+        tint = MaterialTheme.colorScheme.onPrimary
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExpandedSearchBarContent(
+    collapse: () -> Unit,
+    clearText: () -> Unit,
+    searchText: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(focusRequester) {
+        focusRequester.requestFocus()
+    }
+
+    var text by rememberSaveable { mutableStateOf("") }
+    TextField(
+        value = text,
+        onValueChange = {
+            text = it
+            searchText(it)
+        },
+        modifier = modifier.focusRequester(focusRequester),
+        textStyle = MaterialTheme.typography.labelLarge.copy(
+            color = MaterialTheme.colorScheme.onPrimary,
+            lineHeight = 12.sp
+        ),
+        placeholder = {
+            Text(
+                text = stringResource(R.string.search),
+                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.5F),
+                style = MaterialTheme.typography.labelLarge.copy(lineHeight = 12.sp)
+            )
+        },
+        singleLine = true,
+        colors = TextFieldDefaults.textFieldColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            cursorColor = MaterialTheme.colorScheme.onPrimary,
+            unfocusedIndicatorColor = Color.Transparent,
+            focusedIndicatorColor = Color.Transparent,
+            selectionColors = TextSelectionColors(
+                handleColor = MaterialTheme.colorScheme.onPrimary,
+                backgroundColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.3f)
+            )
+        ),
+        keyboardOptions = KeyboardOptions(autoCorrect = false, imeAction = ImeAction.Search),
+        leadingIcon = {
+            IconButton(
+                onClick = collapse,
+                modifier = Modifier.size(dimensionResource(com.imashnake.animite.core.R.dimen.icon_size)),
+                colors = IconButtonDefaults.iconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+        },
+        trailingIcon = {
+            IconButton(
+                onClick = {
+                    text = ""
+                    clearText()
+                },
+                modifier = Modifier.size(dimensionResource(com.imashnake.animite.core.R.dimen.icon_size)),
+                colors = IconButtonDefaults.iconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Close,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+        }
+    )
+
+
+    BackHandler {
+        clearText()
+        collapse()
+    }
+}

--- a/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFab.kt
+++ b/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFab.kt
@@ -43,12 +43,22 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.imashnake.animite.R
 
+/**
+ * A Floating Action Button-esque collapsible search bar. When collapsed, it displays a search icon.
+ * Expanding it reveals a text field with collapse and clear buttons.
+ *
+ * @param isExpanded Whether the search FAB is currently "expanded".
+ * @param setExpanded Called when [isExpanded] should be updated.
+ * @param onSearched Called when the user searches for something. The query may be null, which
+ * suggests nothing was entered in the text field.
+ * @param modifier [Modifier].
+ */
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalAnimationApi::class)
 @Composable
 fun SearchFab(
     isExpanded: Boolean,
-    setExpanded: (Boolean) -> Unit,
-    onSearched: (String?) -> Unit,
+    setExpanded: (expanded: Boolean) -> Unit,
+    onSearched: (query: String?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -80,7 +90,7 @@ fun SearchFab(
 }
 
 @Composable
-fun CollapsedSearchBarContent(
+internal fun CollapsedSearchBarContent(
     expand: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -95,7 +105,7 @@ fun CollapsedSearchBarContent(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ExpandedSearchBarContent(
+internal fun ExpandedSearchBarContent(
     collapse: () -> Unit,
     clearText: () -> Unit,
     searchText: (String) -> Unit,

--- a/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFab.kt
+++ b/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFab.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.TextSelectionColors
-import androidx.compose.material.contentColorFor
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.KeyboardArrowRight
@@ -41,7 +40,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.imashnake.animite.R
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalAnimationApi::class)

--- a/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFab.kt
+++ b/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFab.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldColors
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -122,22 +123,7 @@ fun ExpandedSearchBarContent(
             )
         },
         singleLine = true,
-        colors = TextFieldDefaults.textFieldColors(
-            containerColor = Color.Transparent,
-            cursorColor = LocalContentColor.current,
-            unfocusedIndicatorColor = Color.Transparent,
-            focusedIndicatorColor = Color.Transparent,
-            selectionColors = TextSelectionColors(
-                handleColor = LocalContentColor.current,
-                backgroundColor = LocalContentColor.current.copy(alpha = 0.3f)
-            ),
-            focusedLeadingIconColor = LocalContentColor.current,
-            unfocusedLeadingIconColor = LocalContentColor.current,
-            textColor = LocalContentColor.current,
-            unfocusedTrailingIconColor = LocalContentColor.current,
-            focusedTrailingIconColor = LocalContentColor.current,
-            placeholderColor = LocalContentColor.current.copy(alpha = 0.5F)
-        ),
+        colors = searchTextFieldColors(),
         keyboardOptions = KeyboardOptions(autoCorrect = false, imeAction = ImeAction.Search),
         leadingIcon = {
             IconButton(
@@ -171,4 +157,27 @@ fun ExpandedSearchBarContent(
         clearText()
         collapse()
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun searchTextFieldColors(
+    contentColor: Color = LocalContentColor.current
+): TextFieldColors {
+    return TextFieldDefaults.textFieldColors(
+        containerColor = Color.Transparent,
+        cursorColor = contentColor,
+        unfocusedIndicatorColor = Color.Transparent,
+        focusedIndicatorColor = Color.Transparent,
+        selectionColors = TextSelectionColors(
+            handleColor = contentColor,
+            backgroundColor = contentColor.copy(alpha = 0.3f)
+        ),
+        focusedLeadingIconColor = contentColor,
+        unfocusedLeadingIconColor = contentColor,
+        textColor = contentColor,
+        unfocusedTrailingIconColor = contentColor,
+        focusedTrailingIconColor = contentColor,
+        placeholderColor = contentColor.copy(alpha = 0.5F)
+    )
 }

--- a/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFab.kt
+++ b/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFab.kt
@@ -118,7 +118,6 @@ fun ExpandedSearchBarContent(
         placeholder = {
             Text(
                 text = stringResource(R.string.search),
-                color = LocalContentColor.current.copy(alpha = 0.5F),
                 style = MaterialTheme.typography.labelLarge
             )
         },

--- a/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFab.kt
+++ b/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFab.kt
@@ -9,13 +9,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.material.contentColorFor
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.KeyboardArrowRight
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -71,7 +72,8 @@ fun SearchFab(
                 )
             } else {
                 CollapsedSearchBarContent(
-                    expand = { setExpanded(true) }
+                    expand = { setExpanded(true) },
+                    modifier = Modifier.padding(dimensionResource(R.dimen.search_bar_icon_padding))
                 )
             }
         }
@@ -86,10 +88,9 @@ fun CollapsedSearchBarContent(
     Icon(
         imageVector = ImageVector.vectorResource(R.drawable.search),
         contentDescription = stringResource(R.string.search),
-        modifier = modifier
+        modifier = Modifier
             .clickable(onClick = expand)
-            .padding(dimensionResource(R.dimen.search_bar_icon_padding)),
-        tint = MaterialTheme.colorScheme.onPrimary
+            .then(modifier)
     )
 }
 
@@ -114,42 +115,40 @@ fun ExpandedSearchBarContent(
             searchText(it)
         },
         modifier = modifier.focusRequester(focusRequester),
-        textStyle = MaterialTheme.typography.labelLarge.copy(
-            color = MaterialTheme.colorScheme.onPrimary,
-            lineHeight = 12.sp
-        ),
+        textStyle = MaterialTheme.typography.labelLarge,
         placeholder = {
             Text(
                 text = stringResource(R.string.search),
-                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.5F),
-                style = MaterialTheme.typography.labelLarge.copy(lineHeight = 12.sp)
+                color = LocalContentColor.current.copy(alpha = 0.5F),
+                style = MaterialTheme.typography.labelLarge
             )
         },
         singleLine = true,
         colors = TextFieldDefaults.textFieldColors(
-            containerColor = MaterialTheme.colorScheme.primary,
-            cursorColor = MaterialTheme.colorScheme.onPrimary,
+            containerColor = Color.Transparent,
+            cursorColor = LocalContentColor.current,
             unfocusedIndicatorColor = Color.Transparent,
             focusedIndicatorColor = Color.Transparent,
             selectionColors = TextSelectionColors(
-                handleColor = MaterialTheme.colorScheme.onPrimary,
-                backgroundColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.3f)
-            )
+                handleColor = LocalContentColor.current,
+                backgroundColor = LocalContentColor.current.copy(alpha = 0.3f)
+            ),
+            focusedLeadingIconColor = LocalContentColor.current,
+            unfocusedLeadingIconColor = LocalContentColor.current,
+            textColor = LocalContentColor.current,
+            unfocusedTrailingIconColor = LocalContentColor.current,
+            focusedTrailingIconColor = LocalContentColor.current,
+            placeholderColor = LocalContentColor.current.copy(alpha = 0.5F)
         ),
         keyboardOptions = KeyboardOptions(autoCorrect = false, imeAction = ImeAction.Search),
         leadingIcon = {
             IconButton(
                 onClick = collapse,
-                modifier = Modifier.size(dimensionResource(com.imashnake.animite.core.R.dimen.icon_size)),
-                colors = IconButtonDefaults.iconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary
-                )
+                modifier = Modifier.size(dimensionResource(com.imashnake.animite.core.R.dimen.icon_size))
             ) {
                 Icon(
                     imageVector = Icons.Rounded.KeyboardArrowRight,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimary
+                    contentDescription = null
                 )
             }
         },
@@ -159,23 +158,18 @@ fun ExpandedSearchBarContent(
                     text = ""
                     clearText()
                 },
-                modifier = Modifier.size(dimensionResource(com.imashnake.animite.core.R.dimen.icon_size)),
-                colors = IconButtonDefaults.iconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary
-                )
+                modifier = Modifier.size(dimensionResource(com.imashnake.animite.core.R.dimen.icon_size))
             ) {
                 Icon(
                     imageVector = Icons.Rounded.Close,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimary
+                    contentDescription = null
                 )
             }
         }
     )
 
-
     BackHandler {
+        text = ""
         clearText()
         collapse()
     }

--- a/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFrontDrop.kt
+++ b/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFrontDrop.kt
@@ -91,7 +91,8 @@ fun SearchFrontDrop(
     Box(
         Modifier
             .fillMaxSize()
-            .drawBehind { drawRect(frontDropColor) })
+            .drawBehind { drawRect(frontDropColor) }
+    )
 
     searchList.data?.let {
         SearchList(

--- a/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFrontDrop.kt
+++ b/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFrontDrop.kt
@@ -119,7 +119,10 @@ fun SearchFrontDrop(
         animationSpec = tween(Constants.CROSSFADE_DURATION)
     )
 
-    Box(Modifier.fillMaxSize().drawBehind { drawRect(frontDropColor) })
+    Box(
+        Modifier
+            .fillMaxSize()
+            .drawBehind { drawRect(frontDropColor) })
 
     searchList.data?.let {
         SearchList(
@@ -135,8 +138,10 @@ fun SearchFrontDrop(
         )
     }
 
-    Surface(
-        color = MaterialTheme.colorScheme.primary,
+    SearchFab(
+        isExpanded = isExpanded,
+        setExpanded = { isExpanded = it },
+        onSearched = viewModel::setQuery,
         modifier = modifier
             .landscapeCutoutPadding()
             .padding(bottom = searchBarBottomPadding)
@@ -145,131 +150,7 @@ fun SearchFrontDrop(
                 PaddingValues(bottom = searchBarBottomPadding)
             )
             .imePadding()
-            .height(dimensionResource(R.dimen.search_bar_height)),
-        shadowElevation = 20.dp,
-        shape = CircleShape
-    ) {
-        val keyboardController = LocalSoftwareKeyboardController.current
-        AnimatedContent(targetState = isExpanded) { targetExpanded ->
-            if (targetExpanded) {
-                ExpandedSearchBarContent(
-                    collapse = {
-                        isExpanded = false
-                        viewModel.setQuery(null)
-                        keyboardController?.hide()
-                    },
-                    clearText = { viewModel.setQuery(null) },
-                    searchText = { viewModel.setQuery(it) }
-                )
-            } else {
-                CollapsedSearchBarContent(
-                    expand = { isExpanded = true }
-                )
-            }
-        }
-    }
-
-    BackHandler(isExpanded) {
-        viewModel.setQuery(null)
-        isExpanded = false
-    }
-}
-
-@Composable
-fun CollapsedSearchBarContent(
-    modifier: Modifier = Modifier,
-    expand: () -> Unit
-) {
-    Icon(
-        imageVector = ImageVector.vectorResource(R.drawable.search),
-        contentDescription = stringResource(R.string.search),
-        modifier = modifier
-            .clickable { expand() }
-            .padding(dimensionResource(R.dimen.search_bar_icon_padding)),
-        tint = MaterialTheme.colorScheme.onPrimary
-    )
-}
-
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun ExpandedSearchBarContent(
-    modifier: Modifier = Modifier,
-    collapse: () -> Unit,
-    clearText: () -> Unit,
-    searchText: (String) -> Unit
-) {
-    val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(focusRequester) {
-        focusRequester.requestFocus()
-    }
-
-    var text by rememberSaveable { mutableStateOf("") }
-    TextField(
-        value = text,
-        onValueChange = {
-            text = it
-            searchText(it)
-        },
-        modifier = modifier.focusRequester(focusRequester),
-        textStyle = MaterialTheme.typography.labelLarge.copy(
-            color = MaterialTheme.colorScheme.onPrimary,
-            lineHeight = 12.sp
-        ),
-        placeholder = {
-            Text(
-                text = stringResource(R.string.search),
-                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.5F),
-                style = MaterialTheme.typography.labelLarge.copy(lineHeight = 12.sp)
-            )
-        },
-        singleLine = true,
-        colors = TextFieldDefaults.textFieldColors(
-            containerColor = MaterialTheme.colorScheme.primary,
-            cursorColor = MaterialTheme.colorScheme.onPrimary,
-            unfocusedIndicatorColor = Color.Transparent,
-            focusedIndicatorColor = Color.Transparent,
-            selectionColors = TextSelectionColors(
-                handleColor = MaterialTheme.colorScheme.onPrimary,
-                backgroundColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.3f)
-            )
-        ),
-        keyboardOptions = KeyboardOptions(autoCorrect = false, imeAction = ImeAction.Search),
-        leadingIcon = {
-            IconButton(
-                onClick = collapse,
-                modifier = Modifier.size(dimensionResource(com.imashnake.animite.core.R.dimen.icon_size)),
-                colors = IconButtonDefaults.iconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary
-                )
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.KeyboardArrowRight,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimary
-                )
-            }
-        },
-        trailingIcon = {
-            IconButton(
-                onClick = {
-                    text = ""
-                    clearText()
-                },
-                modifier = Modifier.size(dimensionResource(com.imashnake.animite.core.R.dimen.icon_size)),
-                colors = IconButtonDefaults.iconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary
-                )
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.Close,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimary
-                )
-            }
-        }
+            .height(dimensionResource(R.dimen.search_bar_height))
     )
 }
 

--- a/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFrontDrop.kt
+++ b/app/src/main/java/com/imashnake/animite/features/searchbar/SearchFrontDrop.kt
@@ -1,8 +1,5 @@
 package com.imashnake.animite.features.searchbar
 
-import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
@@ -30,50 +27,26 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material.ContentAlpha
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Close
-import androidx.compose.material.icons.rounded.KeyboardArrowRight
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.pluralStringResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.imashnake.animite.R
 import com.imashnake.animite.core.extensions.landscapeCutoutPadding
@@ -90,11 +63,7 @@ import com.imashnake.animite.type.MediaType
  * @param modifier the [Modifier] to be applied to this Front Drop.
  * @param viewModel [SearchViewModel] instance.
  */
-@OptIn(
-    ExperimentalAnimationApi::class,
-    ExperimentalLayoutApi::class,
-    ExperimentalComposeUiApi::class
-)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun SearchFrontDrop(
     hasExtraPadding: Boolean,


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Attempting to further break down the search component, as well as clean up improper color API usages.

This is a step towards extracting "search" as a feature

**Summary of changes:**

1. Extracted a new SearchFab Composable
2. SearchFab now fully uses inherited colors, and avoids redefining them everywhere.

**Tested changes:**

Seach bar has no visible UI/UX changes (that I have noticed)

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
