### PR TITLE
Updated AGP and Gradle

### DIFF
--- a/.github/workflows/build-debug.yaml
+++ b/.github/workflows/build-debug.yaml
@@ -14,8 +14,8 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
-          java-version: 11
+          distribution: 'zulu'
+          java-version: 17
           cache: 'gradle'
 
       - name: Assemble Debug

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -14,8 +14,8 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
-          java-version: 11
+          distribution: 'zulu'
+          java-version: 17
           cache: 'gradle'
 
       - name: Build App

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: 11
+          java-version: 17
           cache: 'gradle'
 
       - name: Assemble Debug

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -14,8 +14,8 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
-          java-version: 17
+          distribution: 'temurin'
+          java-version: '17'
           cache: 'gradle'
 
       - name: Assemble Debug

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -14,8 +14,8 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: 'zulu'
+          java-version: 17
           cache: 'gradle'
 
       - name: Assemble Debug

--- a/api/anilist/build.gradle.kts
+++ b/api/anilist/build.gradle.kts
@@ -1,7 +1,5 @@
-@file:Suppress("SpellCheckingInspection", "UnstableApiUsage")
+@file:Suppress("UnstableApiUsage")
 
-// TODO: Remove this after https://youtrack.jetbrains.com/issue/KTIJ-19369 is resolved.
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin)
@@ -15,8 +13,6 @@ android {
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/api/anilist/build.gradle.kts
+++ b/api/anilist/build.gradle.kts
@@ -24,12 +24,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 
     namespace = "com.imashnake.animite.api.anilist"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,12 +33,12 @@ android {
 
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 
     buildFeatures {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,5 @@
-@file:Suppress("SpellCheckingInspection", "UnstableApiUsage")
+@file:Suppress("UnstableApiUsage")
 
-// TODO: Remove this after https://youtrack.jetbrains.com/issue/KTIJ-19369 is resolved.
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin)
@@ -51,7 +49,7 @@ android {
         kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
     }
 
-    packagingOptions {
+    packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-// TODO: Remove this after https://github.com/gradle/gradle/issues/22797 is resolved.
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -21,12 +21,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 
     buildFeatures {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,7 +1,5 @@
-@file:Suppress("SpellCheckingInspection", "UnstableApiUsage")
+@file:Suppress("UnstableApiUsage")
 
-// TODO: Remove this after https://youtrack.jetbrains.com/issue/KTIJ-19369 is resolved.
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin)
@@ -12,8 +10,6 @@ android {
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 
 android.useAndroidX=true
 android.nonTransitiveRClass=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ accompanist = "0.28.0"
 
 # Android Gradle Plugin
 # https://developer.android.com/studio/releases/gradle-plugin.
-agp = "8.2.0-alpha01"
+agp = "8.0.0"
 
 # AndroidX
 # https://androidx.tech.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ accompanist = "0.28.0"
 
 # Android Gradle Plugin
 # https://developer.android.com/studio/releases/gradle-plugin.
-agp = "7.4.1"
+agp = "8.0.0"
 
 # AndroidX
 # https://androidx.tech.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ accompanist = "0.28.0"
 
 # Android Gradle Plugin
 # https://developer.android.com/studio/releases/gradle-plugin.
-agp = "8.0.0"
+agp = "8.2.0-alpha01"
 
 # AndroidX
 # https://androidx.tech.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/material-color-utilities/build.gradle.kts
+++ b/material-color-utilities/build.gradle.kts
@@ -1,7 +1,5 @@
 @file:Suppress("UnstableApiUsage")
 
-// TODO: Remove this after https://youtrack.jetbrains.com/issue/KTIJ-19369 is resolved.
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin)
@@ -12,7 +10,6 @@ android {
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
     }
 
     buildTypes {

--- a/material-color-utilities/build.gradle.kts
+++ b/material-color-utilities/build.gradle.kts
@@ -20,12 +20,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 
     namespace = "com.google.material3.color"

--- a/profile/build.gradle.kts
+++ b/profile/build.gradle.kts
@@ -22,12 +22,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 
     buildFeatures {

--- a/profile/build.gradle.kts
+++ b/profile/build.gradle.kts
@@ -1,7 +1,5 @@
-@file:Suppress("SpellCheckingInspection", "UnstableApiUsage")
+@file:Suppress("UnstableApiUsage")
 
-// TODO: Remove this after https://youtrack.jetbrains.com/issue/KTIJ-19369 is resolved.
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin)
@@ -13,8 +11,6 @@ android {
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/rslash/build.gradle.kts
+++ b/rslash/build.gradle.kts
@@ -22,12 +22,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 
     buildFeatures {

--- a/rslash/build.gradle.kts
+++ b/rslash/build.gradle.kts
@@ -1,7 +1,5 @@
-@file:Suppress("SpellCheckingInspection", "UnstableApiUsage")
+@file:Suppress("UnstableApiUsage")
 
-// TODO: Remove this after https://youtrack.jetbrains.com/issue/KTIJ-19369 is resolved.
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin)
@@ -13,8 +11,6 @@ android {
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-@file:Suppress("SpellCheckingInspection", "UnstableApiUsage")
+@file:Suppress("UnstableApiUsage")
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING).

**Summary of changes:**

1. Updated AGP to [8.0.0](https://developer.android.com/build/releases/gradle-plugin#8-0-0).
    - [JDK 17 required to run AGP 8.0](https://developer.android.com/build/releases/gradle-plugin#jdk-17-agp).
        - Also updated workflow to reflect this.
    - Renamed `packagingOptions` to `packaging`.
3. Updated Gradle to [8.1.1](https://docs.gradle.org/8.1.1/release-notes.html).
    - Removed supressions for: [[#22797](https://github.com/gradle/gradle/issues/22797)] - Version catalog accessors for plugin aliases shown as errors in IDE kotlin script editor.
    - [`targetSdk` is deprecated and will be removed from library DSL in v9.0](https://developer.android.com/reference/tools/gradle-api/7.4/com/android/build/api/dsl/LibraryBaseFlavor#targetSdk()).
    - [Configuration cache is stable](https://docs.gradle.org/8.1/release-notes.html#configuration-cache-improvements).

**Tested changes:**

Built app.

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
