### PR TITLE
Hide trailer when null

### DIFF
--- a/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/sanitize/media/Media.kt
+++ b/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/sanitize/media/Media.kt
@@ -24,7 +24,7 @@ data class Media(
     /** @see MediaQuery.Media.characters */
     val characters: List<Character>,
     /** @see MediaQuery.Media.trailer */
-    val trailer: Trailer
+    val trailer: Trailer?
 ) {
     data class Ranking(
         /** @see MediaQuery.Ranking.rank */
@@ -96,12 +96,14 @@ data class Media(
                 )
             }
         },
-        trailer = Trailer(
-            url = if(query.trailer?.site == null || query.trailer.id == null) {
-                null
-            } else "${Trailer.Site.valueOf(query.trailer.site.uppercase()).baseUrl}${query.trailer.id}",
-            thumbnail = query.trailer?.thumbnail
-        )
+        trailer = if(query.trailer?.site == null || query.trailer.id == null) {
+            null
+        } else {
+            Trailer(
+                url = "${Trailer.Site.valueOf(query.trailer.site.uppercase()).baseUrl}${query.trailer.id}",
+                thumbnail = query.trailer.thumbnail
+            )
+        }
     )
 
     data class Medium(


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

The trailer section was shown with no thumbnail even thought it was null, deeplinking caused the app to crash.

**Summary of changes:**

1. Hid the trailer section when either of `site` or `id` is null.

**Tested changes:**

Trailer section is hidden in "One Piece".

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
