### PR TITLE
Higher quality thumbnails

### DIFF
--- a/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/sanitize/media/Media.kt
+++ b/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/sanitize/media/Media.kt
@@ -5,6 +5,10 @@ import com.imashnake.animite.api.anilist.MediaListQuery
 import com.imashnake.animite.api.anilist.MediaQuery
 import com.imashnake.animite.api.anilist.type.MediaRankType
 
+private const val HQ_DEFAULT = "hqdefault"
+private const val MAX_RES_DEFAULT = "maxresdefault"
+private const val SD_DEFAULT = "sddefault"
+
 data class Media(
     /** @see MediaQuery.Media.bannerImage */
     val bannerImage: String?,
@@ -54,7 +58,7 @@ data class Media(
          * @see MediaQuery.Trailer.site */
         val url: String?,
         /** @see MediaQuery.Trailer.thumbnail */
-        val thumbnail: String?,
+        val thumbnail: Thumbnail,
     ) {
         /** @see MediaQuery.Trailer.thumbnail */
         enum class Site(val baseUrl: String) {
@@ -62,6 +66,12 @@ data class Media(
             DAILYMOTION("https://www.dailymotion.com/video/"),
             UNKNOWN("")
         }
+
+        data class Thumbnail(
+            val maxResDefault: String?,
+            val sdDefault: String?,
+            val defaultThumbnail: String?
+        )
     }
 
     internal constructor(query: MediaQuery.Media) : this(
@@ -101,7 +111,17 @@ data class Media(
         } else {
             Trailer(
                 url = "${Trailer.Site.valueOf(query.trailer.site.uppercase()).baseUrl}${query.trailer.id}",
-                thumbnail = query.trailer.thumbnail
+                thumbnail = with(query.trailer) {
+                    Trailer.Thumbnail(
+                        maxResDefault = thumbnail?.takeIf {
+                            it.contains(HQ_DEFAULT)
+                        }?.replace(HQ_DEFAULT, MAX_RES_DEFAULT),
+                        sdDefault = thumbnail?.takeIf {
+                            it.contains(HQ_DEFAULT)
+                        }?.replace(HQ_DEFAULT, SD_DEFAULT),
+                        defaultThumbnail = thumbnail
+                    )
+                }
             )
         }
     )

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -43,7 +43,10 @@ import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -408,16 +411,33 @@ fun MediaTrailer(
             modifier = Modifier
                 .wrapContentSize()
                 .clip(RoundedCornerShape(dimensionResource(R.dimen.trailer_corner_radius)))
+                .background(color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.15f))
                 .clickable {
                     val appIntent = Intent(Intent.ACTION_VIEW, Uri.parse(trailer.url))
                     context.startActivity(appIntent)
                 }
         ) {
+            var bestThumbnail by remember { mutableStateOf(trailer.thumbnail.maxResDefault) }
+
+            val model = ImageRequest.Builder(context)
+                .data(bestThumbnail)
+                .listener(
+                    onError = { _, _ ->
+                        bestThumbnail = trailer.thumbnail.sdDefault
+                    }
+                )
+                .data(bestThumbnail)
+                .listener(
+                    onError = { _, _ ->
+                        bestThumbnail = trailer.thumbnail.defaultThumbnail
+                    }
+                )
+                .data(bestThumbnail)
+                .crossfade(Constants.CROSSFADE_DURATION)
+                .build()
+
             AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(trailer.thumbnail)
-                    .crossfade(Constants.CROSSFADE_DURATION)
-                    .build(),
+                model = model,
                 contentDescription = stringResource(R.string.trailer),
                 contentScale = ContentScale.FillWidth,
                 modifier = Modifier

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -423,19 +423,14 @@ fun MediaTrailer(
                 ImageRequest.Builder(context)
                     .data(bestThumbnail)
                     .apply {
-                        if (bestThumbnail?.contains("maxresdefault") == true) {
-                            listener(
-                                onError = { _, _ ->
-                                    bestThumbnail = trailer.thumbnail.sdDefault
-                                }
-                            )
-                        } else {
-                            listener(
-                                onError = { _, _ ->
-                                    bestThumbnail = trailer.thumbnail.defaultThumbnail
-                                }
-                            )
-                        }
+                        listener(
+                            onError = { _, _ ->
+                                bestThumbnail = if (bestThumbnail?.contains("maxresdefault") == true) {
+                                    trailer.thumbnail.sdDefault
+                                } else trailer.thumbnail.defaultThumbnail
+                                Log.d("bestThumbnail", bestThumbnail.toString())
+                            }
+                        )
                     }
                     .crossfade(Constants.CROSSFADE_DURATION)
                     .build()

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -419,22 +419,27 @@ fun MediaTrailer(
         ) {
             var bestThumbnail by remember { mutableStateOf(trailer.thumbnail.maxResDefault) }
 
-            val model = ImageRequest.Builder(context)
-                .data(bestThumbnail)
-                .listener(
-                    onError = { _, _ ->
-                        bestThumbnail = trailer.thumbnail.sdDefault
+            val model = remember(bestThumbnail) {
+                ImageRequest.Builder(context)
+                    .data(bestThumbnail)
+                    .apply {
+                        if (bestThumbnail?.contains("maxresdefault") == true) {
+                            listener(
+                                onError = { _, _ ->
+                                    bestThumbnail = trailer.thumbnail.sdDefault
+                                }
+                            )
+                        } else {
+                            listener(
+                                onError = { _, _ ->
+                                    bestThumbnail = trailer.thumbnail.defaultThumbnail
+                                }
+                            )
+                        }
                     }
-                )
-                .data(bestThumbnail)
-                .listener(
-                    onError = { _, _ ->
-                        bestThumbnail = trailer.thumbnail.defaultThumbnail
-                    }
-                )
-                .data(bestThumbnail)
-                .crossfade(Constants.CROSSFADE_DURATION)
-                .build()
+                    .crossfade(Constants.CROSSFADE_DURATION)
+                    .build()
+            }
 
             AsyncImage(
                 model = model,

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -417,7 +418,7 @@ fun MediaTrailer(
                     context.startActivity(appIntent)
                 }
         ) {
-            var bestThumbnail by remember { mutableStateOf(trailer.thumbnail.maxResDefault) }
+            var bestThumbnail by rememberSaveable { mutableStateOf(trailer.thumbnail.maxResDefault) }
 
             val model = remember(bestThumbnail) {
                 ImageRequest.Builder(context)
@@ -428,7 +429,6 @@ fun MediaTrailer(
                                 bestThumbnail = if (bestThumbnail?.contains("maxresdefault") == true) {
                                     trailer.thumbnail.sdDefault
                                 } else trailer.thumbnail.defaultThumbnail
-                                Log.d("bestThumbnail", bestThumbnail.toString())
                             }
                         )
                     }


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Replaced default thumbnails with `maxresdefault` and added two more fall backs.

**Summary of changes:**

1. Fallbacks: `maxresdefault` -> `sddefault` -> Default thumbnail from API.

**Tested changes:**

- `maxresdefault` is on most entries.
- "Haikyuu!!" for `sddefault`.
- "Highschool of the Dead" for the default thumbnail. 

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
