### PR TITLE
Shared Element Transitions and Compose Destinations v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ google-services.json
 # Android Profiling
 *.hprof
 lint.xml
+.kotlin/*

--- a/app/src/main/java/com/imashnake/animite/features/MainActivity.kt
+++ b/app/src/main/java/com/imashnake/animite/features/MainActivity.kt
@@ -7,9 +7,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
@@ -27,13 +24,13 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.imashnake.animite.core.ui.LocalPaddings
-import com.imashnake.animite.features.destinations.MediaPageDestination
 import com.imashnake.animite.features.media.MediaPageArgs
 import com.imashnake.animite.features.navigationbar.NavigationBar
 import com.imashnake.animite.features.searchbar.SearchFrontDrop
 import com.imashnake.animite.features.theme.AnimiteTheme
 import com.ramcosta.composedestinations.DestinationsNavHost
-import com.ramcosta.composedestinations.animations.defaults.RootNavGraphDefaultAnimations
+import com.ramcosta.composedestinations.generated.NavGraphs
+import com.ramcosta.composedestinations.generated.destinations.MediaPageDestination
 import com.ramcosta.composedestinations.navigation.navigate
 import com.ramcosta.composedestinations.rememberNavHostEngine
 import com.ramcosta.composedestinations.utils.navGraph
@@ -63,12 +60,7 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun MainScreen(modifier: Modifier = Modifier) {
     val navController = rememberNavController()
-    val navHostEngine = rememberNavHostEngine(
-        rootDefaultAnimations = RootNavGraphDefaultAnimations(
-            enterTransition = { fadeIn(animationSpec = tween(1000)) },
-            exitTransition = { fadeOut(animationSpec = tween(300)) },
-        )
-    )
+    val navHostEngine = rememberNavHostEngine()
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
     val isNavBarVisible = remember(currentBackStackEntry) {
         currentBackStackEntry?.navGraph()?.startRoute == currentBackStackEntry?.route()
@@ -81,14 +73,16 @@ fun MainScreen(modifier: Modifier = Modifier) {
             LocalContentColor provides MaterialTheme.colorScheme.onBackground
         ) {
             DestinationsNavHost(
-                navGraph = RootNavGraph,
+                navGraph = NavGraphs.root,
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .background(MaterialTheme.colorScheme.background)
                     .fillMaxSize(),
                 navController = navController,
                 engine = navHostEngine
-            )
+            ) {
+
+            }
         }
 
         SearchFrontDrop(

--- a/app/src/main/java/com/imashnake/animite/features/RootNavGraph.kt
+++ b/app/src/main/java/com/imashnake/animite/features/RootNavGraph.kt
@@ -8,19 +8,21 @@ import com.ramcosta.composedestinations.spec.DestinationSpec
 import com.ramcosta.composedestinations.spec.NavGraphSpec
 import com.ramcosta.composedestinations.spec.Route
 
-object RootNavGraph : NavGraphSpec {
-    override val route: String = "root"
-
-    // TODO Once Home is refactored to a module, turn off compose-destinations code gen for app module
-    override val destinationsByRoute: Map<String, DestinationSpec<*>> = mapOf(
-        HomeScreenDestination.route to HomeScreenDestination,
-        MediaPageDestination.route to MediaPageDestination
-    )
-
-    override val startRoute: Route = HomeScreenDestination
-
-    override val nestedNavGraphs: List<NavGraphSpec> = listOf(
-        ProfileNavGraph,
-        RslashNavGraph
-    )
-}
+// TODO: New way of setting up compose-destinations for multiple modules:
+//  https://composedestinations.rafaelcosta.xyz/v2/multi-module-setup
+//object RootNavGraph : NavGraphSpec {
+//    override val route: String = "root"
+//
+//    // TODO Once Home is refactored to a module, turn off compose-destinations code gen for app module
+//    override val destinationsByRoute: Map<String, DestinationSpec<*>> = mapOf(
+//        HomeScreenDestination.route to HomeScreenDestination,
+//        MediaPageDestination.route to MediaPageDestination
+//    )
+//
+//    override val startRoute: Route = HomeScreenDestination
+//
+//    override val nestedNavGraphs: List<NavGraphSpec> = listOf(
+//        ProfileNavGraph,
+//        RslashNavGraph
+//    )
+//}

--- a/app/src/main/java/com/imashnake/animite/features/RootNavGraph.kt
+++ b/app/src/main/java/com/imashnake/animite/features/RootNavGraph.kt
@@ -1,12 +1,12 @@
 package com.imashnake.animite.features
 
-import com.imashnake.animite.features.destinations.HomeScreenDestination
-import com.imashnake.animite.features.destinations.MediaPageDestination
-import com.imashnake.animite.profile.ProfileNavGraph
-import com.imashnake.animite.rslash.RslashNavGraph
-import com.ramcosta.composedestinations.spec.DestinationSpec
-import com.ramcosta.composedestinations.spec.NavGraphSpec
-import com.ramcosta.composedestinations.spec.Route
+//import com.imashnake.animite.features.destinations.HomeScreenDestination
+//import com.imashnake.animite.features.destinations.MediaPageDestination
+//import com.imashnake.animite.profile.ProfileNavGraph
+//import com.imashnake.animite.rslash.RslashNavGraph
+//import com.ramcosta.composedestinations.spec.DestinationSpec
+//import com.ramcosta.composedestinations.spec.NavGraphSpec
+//import com.ramcosta.composedestinations.spec.Route
 
 // TODO: New way of setting up compose-destinations for multiple modules:
 //  https://composedestinations.rafaelcosta.xyz/v2/multi-module-setup

--- a/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
@@ -70,10 +70,11 @@ import com.imashnake.animite.features.media.MediaPageArgs
 import com.imashnake.animite.features.ui.MediaSmall
 import com.imashnake.animite.features.ui.MediaSmallRow
 import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.annotation.RootGraph
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.imashnake.animite.core.R as coreR
 
-@Destination
+@Destination<RootGraph>(start = true)
 @Composable
 @Suppress("LongMethod")
 fun HomeScreen(

--- a/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
@@ -65,12 +65,12 @@ import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.ProgressIndicator
 import com.imashnake.animite.core.ui.layouts.BannerLayout
 import com.imashnake.animite.core.ui.layouts.TranslucentStatusBarLayout
-import com.imashnake.animite.features.destinations.MediaPageDestination
 import com.imashnake.animite.features.media.MediaPageArgs
 import com.imashnake.animite.features.ui.MediaSmall
 import com.imashnake.animite.features.ui.MediaSmallRow
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootGraph
+import com.ramcosta.composedestinations.generated.destinations.MediaPageDestination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.imashnake.animite.core.R as coreR
 

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -80,9 +80,10 @@ import com.imashnake.animite.core.extensions.crossfadeModel
 import com.imashnake.animite.features.ui.MediaSmall
 import com.imashnake.animite.features.ui.MediaSmallRow
 import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.annotation.RootGraph
 import com.imashnake.animite.core.R as coreR
 
-@Destination(navArgsDelegate = MediaPageArgs::class)
+@Destination<RootGraph>(navArgs = MediaPageArgs::class)
 @Composable
 @Suppress(
     "CognitiveComplexMethod",

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPageViewModel.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPageViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.imashnake.animite.api.anilist.AnilistMediaRepository
 import com.imashnake.animite.api.anilist.type.MediaType
-import com.imashnake.animite.features.destinations.MediaPageDestination
+import com.ramcosta.composedestinations.generated.destinations.MediaPageDestination
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/imashnake/animite/features/navigationbar/NavigationBar.kt
+++ b/app/src/main/java/com/imashnake/animite/features/navigationbar/NavigationBar.kt
@@ -25,14 +25,14 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
-import com.imashnake.animite.features.destinations.HomeScreenDestination
-import com.imashnake.animite.profile.ProfileNavGraph
-import com.imashnake.animite.rslash.RslashNavGraph
 import com.ramcosta.composedestinations.spec.DestinationSpec
 import com.ramcosta.composedestinations.utils.currentDestinationAsState
 import com.ramcosta.composedestinations.utils.isRouteOnBackStack
 import com.ramcosta.composedestinations.utils.startDestination
 import com.imashnake.animite.R
+import com.ramcosta.composedestinations.generated.destinations.HomeScreenDestination
+import com.ramcosta.composedestinations.generated.rslash.destinations.RslashScreenDestination
+import com.ramcosta.composedestinations.generated.profile.destinations.UserDestination
 import com.imashnake.animite.core.R as coreR
 
 // TODO: Ripple where?
@@ -80,11 +80,11 @@ fun NavigationBar(
 }
 
 enum class NavigationBarPaths(
-    val route: DestinationSpec<*>,
+    val route: DestinationSpec,
     val icon: @Composable () -> Unit
 ) {
     RSlash(
-        RslashNavGraph.startDestination,
+        RslashScreenDestination,
         {
             Icon(
                 imageVector = ImageVector.vectorResource(
@@ -110,7 +110,7 @@ enum class NavigationBarPaths(
         }
     ),
     Profile(
-        ProfileNavGraph.startDestination,
+        UserDestination,
         {
             Icon(
                 imageVector = Icons.Rounded.AccountCircle,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ coil = "2.6.0"
 # TODO: Breaking changes; review release notes and update.
 # Compose Destinations
 # https://github.com/raamcosta/compose-destinations/releases.
-composeDestinations = "1.10.2"
+composeDestinations = "2.0.0-beta09"
 
 # Compose
 # https://developer.android.com/jetpack/androidx/releases/compose.
@@ -93,7 +93,7 @@ androidx-coreKtx = { group = "androidx.core", name = "core-ktx", version.ref = "
 androidx-lifecycleRuntimeKtx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "extJunit" }
 androidx-test-espressoCore = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
-compose-destinations = { group = "io.github.raamcosta.compose-destinations", name = "animations-core", version.ref = "composeDestinations" }
+compose-destinations = { group = "io.github.raamcosta.compose-destinations", name = "core", version.ref = "composeDestinations" }
 compose-destinations-ksp = { group = "io.github.raamcosta.compose-destinations", name = "ksp", version.ref = "composeDestinations" }
 compose-animation = { group = "androidx.compose.animation", name = "animation", version.ref = "composeAnimation" }
 compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "composeFoundation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,6 @@ composeDestinations = "1.10.2"
 # Compose
 # https://developer.android.com/jetpack/androidx/releases/compose.
 composeAnimation = "1.7.0-beta03"
-composeCompiler = "1.5.14"
 composeFoundation = "1.7.0-beta03"
 composeMaterial = "1.7.0-beta03"
 composeMaterial3 = "1.3.0-beta03"

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -42,13 +42,14 @@ import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.NestedScrollableContent
 import com.imashnake.animite.core.ui.layouts.BannerLayout
 import com.imashnake.animite.profile.dev.internal.ANILIST_AUTH_DEEPLINK
-import com.ramcosta.composedestinations.annotation.DeepLink
 import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.annotation.RootNavGraph
+import com.ramcosta.composedestinations.annotation.RootGraph
+import com.ramcosta.composedestinations.annotation.parameters.DeepLink
 import com.imashnake.animite.core.R as coreR
 
 @Suppress("LongMethod", "UNUSED_PARAMETER")
-@Destination(
+@Destination<RootGraph>(
+    start = true,
     route = "user",
     deepLinks = [
         DeepLink(
@@ -56,7 +57,6 @@ import com.imashnake.animite.core.R as coreR
         )
     ]
 )
-@RootNavGraph(start = true)
 @Composable
 fun ProfileScreen(
     viewModel: ProfileViewModel = hiltViewModel(),

--- a/rslash/src/main/kotlin/com/imashnake/animite/rslash/RSlashScreen.kt
+++ b/rslash/src/main/kotlin/com/imashnake/animite/rslash/RSlashScreen.kt
@@ -13,11 +13,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.annotation.RootNavGraph
+import com.ramcosta.composedestinations.annotation.RootGraph
 import com.imashnake.animite.core.R as coreR
 
-@RootNavGraph(start = true)
-@Destination(route = "rslash-screen")
+@Destination<RootGraph>(
+    start = true,
+    route = "rslash-screen"
+)
 @Composable
 fun RSlashScreen() {
     Box(


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Compose Destinations now supports shared element transitions. Going to (try) to share `MediaSmall` of the home screen and media page.

**Summary of changes:**

1. [comment]: # (Summary of changes that reflects changes made in each commit.)

**Tested changes:**

[comment]: # (If changes were tested, replace this comment with a brief description of how you did so. Else replace it with "N/A".)

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
