### PR TITLE
Added Stats to the User's About Tab

### DIFF
--- a/api/anilist/src/main/graphql/UserQuery.graphql
+++ b/api/anilist/src/main/graphql/UserQuery.graphql
@@ -34,6 +34,9 @@ query Viewer {
         bannerImage
         statistics {
             anime {
+                count
+                minutesWatched
+                meanScore
                 genres {
                     genre
                     count

--- a/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/sanitize/profile/Viewer.kt
+++ b/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/sanitize/profile/Viewer.kt
@@ -1,6 +1,8 @@
 package com.imashnake.animite.api.anilist.sanitize.profile
 
 import com.imashnake.animite.api.anilist.ViewerQuery
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.DurationUnit
 
 /**
  * Sanitized [ViewerQuery.Viewer].
@@ -11,7 +13,7 @@ import com.imashnake.animite.api.anilist.ViewerQuery
  * @param avatar
  * @param banner
  * @param count
- * @param minutesWatched
+ * @param daysWatched
  * @param meanScore
  * @param genres
  */
@@ -30,7 +32,7 @@ data class Viewer(
     /** @see ViewerQuery.Anime.count */
     val count: Int?,
     /** @see ViewerQuery.Anime.minutesWatched */
-    val minutesWatched: Int?,
+    val daysWatched: Double?,
     /** @see ViewerQuery.Anime.meanScore */
     val meanScore: Float?,
     /** @see ViewerQuery.Anime.genres */
@@ -57,7 +59,8 @@ data class Viewer(
         avatar = query.avatar?.large,
         banner = query.bannerImage,
         count = query.statistics?.anime?.count,
-        minutesWatched = query.statistics?.anime?.minutesWatched,
+        daysWatched = query.statistics?.anime?.minutesWatched
+            ?.minutes?.toDouble(DurationUnit.DAYS),
         meanScore = query.statistics?.anime?.meanScore?.toFloat(),
         genres = query.statistics?.anime?.genres.orEmpty().filterNotNull().run {
             val totalCount = this.sumOf { genre -> genre.count }

--- a/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/sanitize/profile/Viewer.kt
+++ b/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/sanitize/profile/Viewer.kt
@@ -10,6 +10,9 @@ import com.imashnake.animite.api.anilist.ViewerQuery
  * @param about
  * @param avatar
  * @param banner
+ * @param count
+ * @param minutesWatched
+ * @param meanScore
  * @param genres
  */
 data class Viewer(
@@ -23,10 +26,19 @@ data class Viewer(
     val avatar: String?,
     /** @see ViewerQuery.Viewer.bannerImage */
     val banner: String?,
-    /** @see ViewerQuery.Viewer.statistics */
+    // region About
+    /** @see ViewerQuery.Anime.count */
+    val count: Int?,
+    /** @see ViewerQuery.Anime.minutesWatched */
+    val minutesWatched: Int?,
+    /** @see ViewerQuery.Anime.meanScore */
+    val meanScore: Float?,
+    /** @see ViewerQuery.Anime.genres */
     val genres: List<Genre>
+    // endregion
 ) {
-    /** Sanitized [ViewerQuery.Genre]
+    /**
+     * Sanitized [ViewerQuery.Genre]
      *
      * @param genre
      * @param mediaCount
@@ -44,6 +56,9 @@ data class Viewer(
         about = query.about,
         avatar = query.avatar?.large,
         banner = query.bannerImage,
+        count = query.statistics?.anime?.count,
+        minutesWatched = query.statistics?.anime?.minutesWatched,
+        meanScore = query.statistics?.anime?.meanScore?.toFloat(),
         genres = query.statistics?.anime?.genres.orEmpty().filterNotNull().run {
             val totalCount = this.sumOf { genre -> genre.count }
             mapNotNull {

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.aspectRatio
@@ -69,14 +68,15 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.imashnake.animite.R
 import com.imashnake.animite.api.anilist.sanitize.media.Media
+import com.imashnake.animite.core.Constants
 import com.imashnake.animite.core.extensions.bannerParallax
+import com.imashnake.animite.core.extensions.crossfadeModel
 import com.imashnake.animite.core.extensions.landscapeCutoutPadding
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.NestedScrollableContent
+import com.imashnake.animite.core.ui.StatsRow
 import com.imashnake.animite.core.ui.layouts.BannerLayout
 import com.imashnake.animite.core.ui.layouts.TranslucentStatusBarLayout
-import com.imashnake.animite.core.Constants
-import com.imashnake.animite.core.extensions.crossfadeModel
 import com.imashnake.animite.features.ui.MediaSmall
 import com.imashnake.animite.features.ui.MediaSmallRow
 import com.ramcosta.composedestinations.annotation.Destination
@@ -130,13 +130,29 @@ fun MediaPage(
                         )
 
                         if (!media.ranks.isNullOrEmpty()) {
-                            MediaRankings(
-                                rankings = media.ranks,
+                            StatsRow(
+                                stats = media.ranks,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .padding(horizontal = LocalPaddings.current.large)
                                     .landscapeCutoutPadding()
-                            )
+                            ) {
+                                Text(
+                                    text = it.type.name,
+                                    color = MaterialTheme.colorScheme.onBackground,
+                                    style = MaterialTheme.typography.labelSmall
+                                )
+
+                                Text(
+                                    text = when (it.type) {
+                                        Media.Ranking.Type.SCORE -> "${it.rank}%"
+                                        Media.Ranking.Type.RATED,
+                                        Media.Ranking.Type.POPULAR -> "#${it.rank}"
+                                    },
+                                    color = MaterialTheme.colorScheme.onBackground,
+                                    style = MaterialTheme.typography.displaySmall
+                                )
+                            }
                         }
 
                         if (!media.genres.isNullOrEmpty()) {
@@ -284,40 +300,6 @@ fun MediaDetails(
                 update = { it.text = html },
                 modifier = contentModifier
             )
-        }
-    }
-}
-
-@Composable
-fun MediaRankings(
-    rankings: List<Media.Ranking>,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceAround,
-        modifier = modifier
-    ) {
-        rankings.forEach { ranking ->
-            Column(
-                verticalArrangement = Arrangement.SpaceEvenly,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text(
-                    text = ranking.type.name,
-                    color = MaterialTheme.colorScheme.onBackground,
-                    style = MaterialTheme.typography.labelSmall
-                )
-
-                Text(
-                    text = when (ranking.type) {
-                        Media.Ranking.Type.SCORE -> "${ranking.rank}%"
-                        Media.Ranking.Type.RATED, Media.Ranking.Type.POPULAR -> "#${ranking.rank}"
-                    },
-                    color = MaterialTheme.colorScheme.onBackground,
-                    style = MaterialTheme.typography.displaySmall
-                )
-            }
         }
     }
 }

--- a/core/src/main/kotlin/com/imashnake/animite/core/ui/Stats.kt
+++ b/core/src/main/kotlin/com/imashnake/animite/core/ui/Stats.kt
@@ -1,0 +1,30 @@
+package com.imashnake.animite.core.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun <T> StatsRow(
+    stats: List<T>,
+    modifier: Modifier = Modifier,
+    content: @Composable (T) -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceAround,
+        modifier = modifier
+    ) {
+        stats.forEach { stat ->
+            Column(
+                verticalArrangement = Arrangement.SpaceEvenly,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                content(stat)
+            }
+        }
+    }
+}

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -262,7 +262,7 @@ fun AboutTab(
             .padding(LocalPaddings.current.large),
         verticalArrangement = Arrangement.spacedBy(LocalPaddings.current.medium)
     ) {
-        Genres(viewer.genres)
+        if (viewer.genres.isNotEmpty()) Genres(viewer.genres)
     }
 }
 

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -59,6 +60,7 @@ import com.imashnake.animite.core.extensions.landscapeCutoutPadding
 import com.imashnake.animite.core.extensions.maxHeight
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.NestedScrollableContent
+import com.imashnake.animite.core.ui.StatsRow
 import com.imashnake.animite.core.ui.layouts.BannerLayout
 import com.imashnake.animite.profile.dev.internal.ANILIST_AUTH_DEEPLINK
 import com.ramcosta.composedestinations.annotation.DeepLink
@@ -251,23 +253,53 @@ enum class ProfileTabs(@StringRes val titleRes: Int) {
 }
 
 @Composable
-fun AboutTab(
+private fun AboutTab(
     viewer: Viewer,
     modifier: Modifier = Modifier
 ) {
     val scrollState = rememberScrollState()
+
+    val statsLabelToValue = listOf(
+        stringResource(R.string.total_anime) to viewer.count?.toString(),
+        stringResource(R.string.days_watched) to viewer.daysWatched?.let { "%.1f".format(it) },
+        stringResource(R.string.mean_score) to viewer.meanScore?.let { "%.1f".format(it) }
+    ).filter { it.second != null }
+
     Column(
         modifier = modifier
             .verticalScroll(scrollState)
             .padding(LocalPaddings.current.large),
         verticalArrangement = Arrangement.spacedBy(LocalPaddings.current.medium)
     ) {
+        StatsRow(
+            stats = statsLabelToValue,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = LocalPaddings.current.large)
+                .landscapeCutoutPadding()
+        ) {
+            Text(
+                text = it.first,
+                color = MaterialTheme.colorScheme.onBackground,
+                style = MaterialTheme.typography.labelSmall,
+                textAlign = TextAlign.Center
+            )
+
+            it.second?.let { value ->
+                Text(
+                    text = value,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    style = MaterialTheme.typography.displaySmall
+                )
+            }
+        }
+
         if (viewer.genres.isNotEmpty()) Genres(viewer.genres)
     }
 }
 
 @Composable
-fun Genres(
+private fun Genres(
     genres: List<Viewer.Genre>,
     modifier: Modifier = Modifier
 ) {

--- a/profile/src/main/res/values/strings.xml
+++ b/profile/src/main/res/values/strings.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="genres">Genres</string>
-
     <string name="about">About</string>
     <string name="anime">Anime</string>
     <string name="manga">Manga</string>
     <string name="favourites">Fave</string>
     <string name="statistics">Stats</string>
+    
+    <string name="total_anime">TOTAL\nANIME</string>
+    <string name="days_watched">DAYS\nWATCHED</string>
+    <string name="mean_score">MEAN\nSCORE</string>
+
+    <string name="genres">Genres</string>
 </resources>


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Added the stats that appear in the "Overview" tab of Anilist.

**Summary of changes:**

1. Created a common `StatsRow` for `MediaPage` rankings and user's stats.

**Tested changes:** 👍 

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
