### PR TITLE
Shared Element Transition -> `HomeScreen` to `MediaPage` (Part 2)

### DIFF
--- a/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
@@ -233,11 +233,14 @@ fun HomeRow(
                     image = media.coverImage,
                     label = media.title,
                     onClick = { onItemClicked(media) },
-                    modifier = Modifier.width(dimensionResource(coreR.dimen.media_card_width)),
+                    modifier = Modifier.sharedBounds(
+                        rememberSharedContentState("media_small_card_${media.id}_${type.name}"),
+                        animatedVisibilityScope
+                    ).width(dimensionResource(coreR.dimen.media_card_width)),
                     imageModifier = Modifier.sharedBounds(
-                        rememberSharedContentState("media_small_${media.id}_${type.name}"),
+                        rememberSharedContentState("media_small_image_${media.id}_${type.name}"),
                         animatedVisibilityScope,
-                    )
+                    ),
                 )
             }
         }

--- a/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
@@ -233,10 +233,12 @@ fun HomeRow(
                     image = media.coverImage,
                     label = media.title,
                     onClick = { onItemClicked(media) },
-                    modifier = Modifier.sharedBounds(
-                        rememberSharedContentState("media_small_card_${media.id}_${type.name}"),
-                        animatedVisibilityScope
-                    ).width(dimensionResource(coreR.dimen.media_card_width)),
+                    modifier = Modifier
+                        .sharedBounds(
+                            rememberSharedContentState("media_small_card_${media.id}_${type.name}"),
+                            animatedVisibilityScope
+                        )
+                        .width(dimensionResource(coreR.dimen.media_card_width)),
                     imageModifier = Modifier.sharedBounds(
                         rememberSharedContentState("media_small_image_${media.id}_${type.name}"),
                         animatedVisibilityScope,

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -105,107 +105,111 @@ fun MediaPage(
             scrollState = scrollState,
             modifier = Modifier.background(MaterialTheme.colorScheme.background)
         ) {
-            Box(
-                Modifier
-                    .fillMaxSize()
-                    .verticalScroll(scrollState)
-                    .padding(bottom = LocalPaddings.current.large)
-            ) {
-                BannerLayout(
-                    banner = { bannerModifier ->
-                        MediaBanner(
-                            imageUrl = media.bannerImage,
-                            tintColor = Color(media.color ?: 0).copy(alpha = 0.25f),
-                            modifier = bannerModifier.bannerParallax(scrollState)
+            with(sharedTransitionScope) {
+                Box(
+                    Modifier
+                        .sharedBounds(
+                            rememberSharedContentState("media_small_card_${media.id}_${media.source}"),
+                            animatedVisibilityScope,
                         )
-                    },
-                    content = {
-                        MediaDetails(
-                            title = media.title.orEmpty(),
-                            description = media.description.orEmpty(),
-                            modifier = Modifier
-                                .padding(
-                                    start = LocalPaddings.current.large
-                                            + dimensionResource(coreR.dimen.media_card_width)
-                                            + LocalPaddings.current.large,
-                                    end = LocalPaddings.current.large
-                                )
-                                .landscapeCutoutPadding()
-                                .height(dimensionResource(R.dimen.media_details_height))
-                        )
-
-                        if (!media.ranks.isNullOrEmpty()) {
-                            StatsRow(
-                                stats = media.ranks,
+                        .fillMaxSize()
+                        .verticalScroll(scrollState)
+                        .padding(bottom = LocalPaddings.current.large)
+                ) {
+                    BannerLayout(
+                        banner = { bannerModifier ->
+                            MediaBanner(
+                                imageUrl = media.bannerImage,
+                                tintColor = Color(media.color ?: 0).copy(alpha = 0.25f),
+                                modifier = bannerModifier.bannerParallax(scrollState)
+                            )
+                        },
+                        content = {
+                            MediaDetails(
+                                title = media.title.orEmpty(),
+                                description = media.description.orEmpty(),
                                 modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = LocalPaddings.current.large)
+                                    .padding(
+                                        start = LocalPaddings.current.large
+                                                + dimensionResource(coreR.dimen.media_card_width)
+                                                + LocalPaddings.current.large,
+                                        end = LocalPaddings.current.large
+                                    )
                                     .landscapeCutoutPadding()
-                            ) {
-                                Text(
-                                    text = it.type.name,
-                                    color = MaterialTheme.colorScheme.onBackground,
-                                    style = MaterialTheme.typography.labelSmall
-                                )
+                                    .height(dimensionResource(R.dimen.media_details_height))
+                            )
 
-                                Text(
-                                    text = when (it.type) {
-                                        Media.Ranking.Type.SCORE -> "${it.rank}%"
-                                        Media.Ranking.Type.RATED,
-                                        Media.Ranking.Type.POPULAR -> "#${it.rank}"
-                                    },
-                                    color = MaterialTheme.colorScheme.onBackground,
-                                    style = MaterialTheme.typography.displaySmall
+                            if (!media.ranks.isNullOrEmpty()) {
+                                StatsRow(
+                                    stats = media.ranks,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = LocalPaddings.current.large)
+                                        .landscapeCutoutPadding()
+                                ) {
+                                    Text(
+                                        text = it.type.name,
+                                        color = MaterialTheme.colorScheme.onBackground,
+                                        style = MaterialTheme.typography.labelSmall
+                                    )
+
+                                    Text(
+                                        text = when (it.type) {
+                                            Media.Ranking.Type.SCORE -> "${it.rank}%"
+                                            Media.Ranking.Type.RATED,
+                                            Media.Ranking.Type.POPULAR -> "#${it.rank}"
+                                        },
+                                        color = MaterialTheme.colorScheme.onBackground,
+                                        style = MaterialTheme.typography.displaySmall
+                                    )
+                                }
+                            }
+
+                            if (!media.genres.isNullOrEmpty()) {
+                                MediaGenres(
+                                    genres = media.genres,
+                                    contentPadding = PaddingValues(
+                                        start = LocalPaddings.current.large + if (
+                                            LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+                                        ) {
+                                            WindowInsets.displayCutout.asPaddingValues()
+                                                .calculateLeftPadding(LayoutDirection.Ltr)
+                                        } else 0.dp,
+                                        end = LocalPaddings.current.large
+                                    ),
+                                    color = Color(media.color ?: 0xFF152232.toInt()),
                                 )
                             }
-                        }
 
-                        if (!media.genres.isNullOrEmpty()) {
-                            MediaGenres(
-                                genres = media.genres,
-                                contentPadding = PaddingValues(
-                                    start = LocalPaddings.current.large + if (
-                                        LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
-                                    ) {
-                                        WindowInsets.displayCutout.asPaddingValues()
-                                            .calculateLeftPadding(LayoutDirection.Ltr)
-                                    } else 0.dp,
-                                    end = LocalPaddings.current.large
-                                ),
-                                color = Color(media.color ?: 0xFF152232.toInt()),
-                            )
-                        }
+                            if (!media.characters.isNullOrEmpty()) {
+                                MediaCharacters(
+                                    characters = media.characters,
+                                )
+                            }
 
-                        if (!media.characters.isNullOrEmpty()) {
-                            MediaCharacters(
-                                characters = media.characters,
-                            )
-                        }
+                            if (media.trailer != null) {
+                                MediaTrailer(
+                                    trailer = media.trailer,
+                                    modifier = Modifier
+                                        .padding(horizontal = LocalPaddings.current.large)
+                                        .landscapeCutoutPadding()
+                                )
+                            }
+                        },
+                        contentModifier = Modifier.padding(top = LocalPaddings.current.medium)
+                    )
 
-                        if (media.trailer != null) {
-                            MediaTrailer(
-                                trailer = media.trailer,
-                                modifier = Modifier
-                                    .padding(horizontal = LocalPaddings.current.large)
-                                    .landscapeCutoutPadding()
-                            )
-                        }
-                    },
-                    contentModifier = Modifier.padding(top = LocalPaddings.current.medium)
-                )
+                    // TODO: https://developer.android.com/jetpack/compose/animation/quick-guide#concurrent-animations
+                    val offset by animateDpAsState(
+                        targetValue = if (scrollState.value == 0) {
+                            0.dp
+                        } else {
+                            dimensionResource(coreR.dimen.media_card_height) - dimensionResource(R.dimen.media_details_height)
+                        },
+                        animationSpec = tween(durationMillis = 750),
+                        label = "media_card_height"
+                    )
 
-                // TODO: https://developer.android.com/jetpack/compose/animation/quick-guide#concurrent-animations
-                val offset by animateDpAsState(
-                    targetValue = if (scrollState.value == 0) {
-                        0.dp
-                    } else {
-                        dimensionResource(coreR.dimen.media_card_height) - dimensionResource(R.dimen.media_details_height)
-                    },
-                    animationSpec = tween(durationMillis = 750),
-                    label = "media_card_height"
-                )
-
-                with(sharedTransitionScope) {
                     Box(
                         modifier = Modifier
                             .statusBarsPadding()
@@ -229,7 +233,7 @@ fun MediaPage(
                             onClick = {},
                             modifier = Modifier.width(dimensionResource(coreR.dimen.media_card_width)),
                             imageModifier = Modifier.sharedBounds(
-                                rememberSharedContentState("media_small_${media.id}_${media.source}"),
+                                rememberSharedContentState("media_small_image_${media.id}_${media.source}"),
                                 animatedVisibilityScope,
                             ),
                         )

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -7,6 +7,8 @@ import android.text.method.LinkMovementMethod
 import android.util.Log
 import android.widget.TextView
 import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.animateDpAsState
@@ -85,6 +87,9 @@ import com.imashnake.animite.core.ui.layouts.TranslucentStatusBarLayout
 import kotlinx.serialization.Serializable
 import com.imashnake.animite.core.R as coreR
 
+// TODO: Need to use WindowInsets to get device corner radius if available.
+private const val DEVICE_CORNER_RADIUS = 30
+
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 @Suppress(
@@ -111,7 +116,12 @@ fun MediaPage(
                         .sharedBounds(
                             rememberSharedContentState("media_small_card_${media.id}_${media.source}"),
                             animatedVisibilityScope,
+                            resizeMode = SharedTransitionScope.ResizeMode.RemeasureToBounds,
+                            clipInOverlayDuringTransition = OverlayClip(
+                                RoundedCornerShape(DEVICE_CORNER_RADIUS.dp)
+                            ),
                         )
+                        .clip(RoundedCornerShape(DEVICE_CORNER_RADIUS.dp))
                         .fillMaxSize()
                         .verticalScroll(scrollState)
                         .padding(bottom = LocalPaddings.current.large)
@@ -129,6 +139,7 @@ fun MediaPage(
                                 title = media.title.orEmpty(),
                                 description = media.description.orEmpty(),
                                 modifier = Modifier
+                                    .skipToLookaheadSize()
                                     .padding(
                                         start = LocalPaddings.current.large
                                                 + dimensionResource(coreR.dimen.media_card_width)
@@ -231,11 +242,13 @@ fun MediaPage(
                         MediaSmall(
                             image = media.coverImage,
                             onClick = {},
-                            modifier = Modifier.width(dimensionResource(coreR.dimen.media_card_width)),
-                            imageModifier = Modifier.sharedBounds(
-                                rememberSharedContentState("media_small_image_${media.id}_${media.source}"),
-                                animatedVisibilityScope,
-                            ),
+                            modifier = Modifier
+                                .sharedBounds(
+                                    rememberSharedContentState("media_small_image_${media.id}_${media.source}"),
+                                    animatedVisibilityScope,
+                                )
+                                .width(dimensionResource(coreR.dimen.media_card_width)),
+                            imageModifier = Modifier
                         )
                     }
                 }


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Now the cards transition to the media page.

**Summary of changes:**

1. Shared bounds of the media cards and media page.
2. Used [shared element APIs](https://developer.android.com/develop/ui/compose/animation/shared-elements/) to handle a couple elements:
    - [Changed `resizeMode`](https://developer.android.com/develop/ui/compose/animation/shared-elements/customize#resize-mode).
    - [Clipped bounds to "a" corner radius](https://developer.android.com/develop/ui/compose/animation/shared-elements/customize#clip-overlays).
    - [`skipToLookaheadSize` for text](https://developer.android.com/develop/ui/compose/animation/shared-elements/customize#skip-final).
    - Changed shared bounds from image-to-image to image-to-card to prevent default translucent background of card from being shown on navigating back.

**Tested changes:**

oh hell yeah

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
