### PR TITLE
Consolidated `HomeRow` Animations

### DIFF
--- a/core/src/main/kotlin/com/imashnake/animite/core/ui/MediaSmall.kt
+++ b/core/src/main/kotlin/com/imashnake/animite/core/ui/MediaSmall.kt
@@ -1,11 +1,6 @@
 package com.imashnake.animite.core.ui
 
 import android.content.res.Configuration
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -66,29 +61,20 @@ fun <T> MediaSmallRow(
                     .landscapeCutoutPadding()
             )
         }
-
-        AnimatedContent(
-            targetState = mediaList,
-            transitionSpec = {
-                fadeIn(tween(500)).togetherWith(fadeOut(tween(500)))
-            },
-            label = "animate_media_list_content"
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(LocalPaddings.current.small),
+            contentPadding = PaddingValues(
+                start = LocalPaddings.current.large + if (
+                    LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+                ) {
+                    WindowInsets.displayCutout.asPaddingValues()
+                        .calculateLeftPadding(LayoutDirection.Ltr)
+                } else 0.dp,
+                end = LocalPaddings.current.large
+            )
         ) {
-            LazyRow(
-                horizontalArrangement = Arrangement.spacedBy(LocalPaddings.current.small),
-                contentPadding = PaddingValues(
-                    start = LocalPaddings.current.large + if (
-                        LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
-                    ) {
-                        WindowInsets.displayCutout.asPaddingValues()
-                            .calculateLeftPadding(LayoutDirection.Ltr)
-                    } else 0.dp,
-                    end = LocalPaddings.current.large
-                )
-            ) {
-                items(it) { media ->
-                    content(media)
-                }
+            items(mediaList) { media ->
+                content(media)
             }
         }
     }


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Before this, we had `AnimatedContent` for `MediaSmallRow`'s `LazyRow` and `AnimatedVisibility` for `MediaSmallRow`. This PR removes both these animations and consolidates it into a single `AnimatedContent` animation for `HomeRow`.

**Summary of changes:**

1. Consolidated animations.

**Tested changes:**
Looks pretty similar to the previous animation without the jank.

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
