### PR TITLE
jvmToolchain 21

### DIFF
--- a/.github/workflows/build-debug.yaml
+++ b/.github/workflows/build-debug.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
           cache: 'gradle'
 
       - name: Assemble Debug

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
           cache: 'gradle'
 
       - name: Prepare signing keystore

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 21
           cache: 'gradle'
 
       - name: Assemble Debug

--- a/api/anilist/build.gradle.kts
+++ b/api/anilist/build.gradle.kts
@@ -19,7 +19,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/api/preferences/build.gradle.kts
+++ b/api/preferences/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -22,7 +22,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/material-color-utilities/build.gradle.kts
+++ b/material-color-utilities/build.gradle.kts
@@ -15,5 +15,5 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -23,7 +23,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/profile/build.gradle.kts
+++ b/profile/build.gradle.kts
@@ -24,7 +24,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Android Studio is (or will very soon be) bundling Java 21, which means jvmToolchain(17) is an error. Merge this when you update your IDE

**Summary of changes:**

1. jvmToolchain 21

**Tested changes:**

App still builds (I've been using these changes locally for a while

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
