### PR TITLE
Stop Using Aspect Ratio

### DIFF
--- a/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
@@ -256,16 +256,20 @@ fun HomeRow(
                         animatedVisibilityScope
                     )
                     .width(dimensionResource(coreR.dimen.media_card_width)),
-                imageModifier = Modifier.sharedBounds(
-                    rememberSharedContentState(
-                        SharedContentKey(
-                            id = media.id,
-                            source = type.name,
-                            sharedComponents = Image to Image,
-                        )
+                imageModifier = Modifier
+                    .sharedBounds(
+                        rememberSharedContentState(
+                            SharedContentKey(
+                                id = media.id,
+                                source = type.name,
+                                sharedComponents = Image to Image,
+                            )
+                        ),
+                        animatedVisibilityScope,
+                    )
+                    .height(
+                        height = dimensionResource(coreR.dimen.media_image_height),
                     ),
-                    animatedVisibilityScope,
-                ),
                 textModifier = Modifier.sharedBounds(
                     rememberSharedContentState(
                         SharedContentKey(

--- a/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
@@ -267,9 +267,7 @@ fun HomeRow(
                         ),
                         animatedVisibilityScope,
                     )
-                    .height(
-                        height = dimensionResource(coreR.dimen.media_image_height),
-                    ),
+                    .height(dimensionResource(coreR.dimen.media_image_height)),
                 textModifier = Modifier.sharedBounds(
                     rememberSharedContentState(
                         SharedContentKey(

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -234,7 +234,7 @@ fun MediaPage(
                         targetValue = if (scrollState.value == 0) {
                             0.dp
                         } else {
-                            dimensionResource(coreR.dimen.media_card_height) - dimensionResource(R.dimen.media_details_height)
+                            dimensionResource(coreR.dimen.media_image_height) - dimensionResource(R.dimen.media_details_height)
                         },
                         animationSpec = tween(durationMillis = 750),
                         label = "media_card_height"
@@ -251,12 +251,12 @@ fun MediaPage(
                                         - WindowInsets.statusBars
                                     .asPaddingValues()
                                     .calculateTopPadding()
-                                        - dimensionResource(coreR.dimen.media_card_height)
+                                        - dimensionResource(coreR.dimen.media_image_height)
                                         + offset,
                                 start = LocalPaddings.current.large
                             )
                             .landscapeCutoutPadding()
-                            .height(dimensionResource(coreR.dimen.media_card_height) - offset)
+                            .height(dimensionResource(coreR.dimen.media_image_height) - offset)
                     ) {
                         MediaSmall(
                             image = media.coverImage,
@@ -411,7 +411,8 @@ fun MediaCharacters(
             image = character.image,
             label = character.name,
             onClick = { Log.d("CharacterId", "${character.id}") },
-            modifier = Modifier.width(dimensionResource(R.dimen.character_card_width))
+            modifier = Modifier.width(dimensionResource(R.dimen.character_card_width)),
+            imageModifier = Modifier.height(dimensionResource(R.dimen.character_image_height)),
         )
     }
 }
@@ -419,7 +420,7 @@ fun MediaCharacters(
 @Composable
 fun MediaTrailer(
     trailer: Media.Trailer,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier,

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -273,7 +273,9 @@ fun MediaPage(
                                     animatedVisibilityScope,
                                 )
                                 .width(dimensionResource(coreR.dimen.media_card_width)),
-                            imageModifier = Modifier
+                            imageModifier = Modifier.height(
+                                dimensionResource(coreR.dimen.media_image_height)
+                            ),
                         )
                     }
                 }

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,6 +2,7 @@
 <resources>
     <dimen name="media_details_height">172dp</dimen>
     <dimen name="character_card_width">96dp</dimen>
+    <dimen name="character_image_height">137dp</dimen>
     <dimen name="trailer_corner_radius">30dp</dimen>
 
     <dimen name="search_bar_icon_padding">16dp</dimen>

--- a/core/src/main/kotlin/com/imashnake/animite/core/ui/MediaSmall.kt
+++ b/core/src/main/kotlin/com/imashnake/animite/core/ui/MediaSmall.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -110,7 +109,6 @@ fun MediaSmall(
             contentScale = ContentScale.Crop,
             modifier = imageModifier
                 .fillMaxWidth()
-                .aspectRatio(0.7f)
                 .clip(RoundedCornerShape(dimensionResource(R.dimen.media_card_corner_radius)))
         )
 

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -20,7 +20,7 @@
     <dimen name="banner_height">168dp</dimen>
 
     <dimen name="media_card_width">140dp</dimen>
-    <dimen name="media_card_height">200dp</dimen>
+    <dimen name="media_image_height">200dp</dimen>
     <dimen name="media_card_corner_radius">18dp</dimen>
     <dimen name="media_card_text_padding_horizontal">16dp</dimen>
     <dimen name="media_card_text_padding_vertical">10dp</dimen>


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Initially, aspect ratio was used to configure the height of the media images, it should be something that we can change for creating a funi list. Now, we set a width to the cards and a height to the images since the height of the cards can change depending on `label`.

**Summary of changes:**

1. Stop using aspect ratio.

**Tested changes:**

No UI changes.

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
