### PR TITLE
Carousel

### DIFF
--- a/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
@@ -240,7 +240,7 @@ fun HomeRow(
     animatedVisibilityScope: AnimatedVisibilityScope,
     modifier: Modifier = Modifier
 ) {
-    MediaSmallRow(type.title, list, modifier) { media, clipModifier ->
+    MediaSmallRow(type.title, list, dimensionResource(coreR.dimen.media_card_width), modifier) { media, clipModifier ->
         with(sharedTransitionScope) {
             MediaSmall(
                 image = media.coverImage,

--- a/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
@@ -240,7 +240,12 @@ fun HomeRow(
     animatedVisibilityScope: AnimatedVisibilityScope,
     modifier: Modifier = Modifier
 ) {
-    MediaSmallRow(type.title, list, dimensionResource(coreR.dimen.media_card_width), modifier) { media, clipModifier ->
+    MediaSmallRow(
+        title = type.title,
+        mediaList = list,
+        mediaWidth = dimensionResource(coreR.dimen.media_card_width),
+        modifier = modifier
+    ) { media, clipModifier ->
         with(sharedTransitionScope) {
             MediaSmall(
                 image = media.coverImage,

--- a/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/java/com/imashnake/animite/features/home/HomeScreen.kt
@@ -36,8 +36,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -238,7 +240,7 @@ fun HomeRow(
     animatedVisibilityScope: AnimatedVisibilityScope,
     modifier: Modifier = Modifier
 ) {
-    MediaSmallRow(type.title, list, modifier) { media ->
+    MediaSmallRow(type.title, list, modifier) { media, clipModifier ->
         with(sharedTransitionScope) {
             MediaSmall(
                 image = media.coverImage,
@@ -246,7 +248,7 @@ fun HomeRow(
                 onClick = { onItemClicked(media) },
                 imageHeight = dimensionResource(coreR.dimen.media_image_height),
                 cardWidth = dimensionResource(coreR.dimen.media_card_width),
-                modifier = Modifier.sharedBounds(
+                modifier = clipModifier.sharedBounds(
                     rememberSharedContentState(
                         SharedContentKey(
                             id = media.id,

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -404,14 +404,15 @@ fun MediaCharacters(
         title = stringResource(R.string.characters),
         mediaList = characters,
         mediaWidth = dimensionResource(R.dimen.character_card_width),
-        modifier = modifier
-    ) { character, _ ->
+        modifier = modifier,
+    ) { character, clipModifier ->
         MediaSmall(
             image = character.image,
             label = character.name,
             onClick = { Log.d("CharacterId", "${character.id}") },
             imageHeight = dimensionResource(R.dimen.character_image_height),
             cardWidth = dimensionResource(R.dimen.character_card_width),
+            modifier = clipModifier,
         )
     }
 }

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -403,6 +403,7 @@ fun MediaCharacters(
     MediaSmallRow(
         title = stringResource(R.string.characters),
         mediaList = characters,
+        mediaWidth = dimensionResource(R.dimen.character_card_width),
         modifier = modifier
     ) { character, _ ->
         MediaSmall(

--- a/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
+++ b/app/src/main/java/com/imashnake/animite/features/media/MediaPage.kt
@@ -404,7 +404,7 @@ fun MediaCharacters(
         title = stringResource(R.string.characters),
         mediaList = characters,
         modifier = modifier
-    ) { character ->
+    ) { character, _ ->
         MediaSmall(
             image = character.image,
             label = character.name,

--- a/core/src/main/kotlin/com/imashnake/animite/core/ui/MediaSmall.kt
+++ b/core/src/main/kotlin/com/imashnake/animite/core/ui/MediaSmall.kt
@@ -54,6 +54,7 @@ import com.imashnake.animite.core.extensions.landscapeCutoutPadding
 fun <T> MediaSmallRow(
     title: String?,
     mediaList: List<T>,
+    mediaWidth: Dp,
     modifier: Modifier = Modifier,
     content: @Composable (T, Modifier) -> Unit
 ) {
@@ -83,7 +84,7 @@ fun <T> MediaSmallRow(
                 } else 0.dp,
                 end = LocalPaddings.current.large
             ),
-            itemWidth = dimensionResource(R.dimen.media_card_width),
+            itemWidth = mediaWidth,
             itemSpacing = LocalPaddings.current.small,
         ) { index ->
             content(mediaList[index], Modifier.maskClip(

--- a/core/src/main/kotlin/com/imashnake/animite/core/ui/MediaSmall.kt
+++ b/core/src/main/kotlin/com/imashnake/animite/core/ui/MediaSmall.kt
@@ -1,6 +1,10 @@
 package com.imashnake.animite.core.ui
 
 import android.content.res.Configuration
+import androidx.compose.foundation.gestures.TargetedFlingBehavior
+import androidx.compose.foundation.gestures.snapping.SnapLayoutInfoProvider
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.gestures.snapping.snapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,8 +21,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.carousel.HorizontalMultiBrowseCarousel
+import androidx.compose.material3.carousel.HorizontalUncontainedCarousel
+import androidx.compose.material3.carousel.rememberCarouselState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,12 +49,13 @@ import com.imashnake.animite.core.extensions.landscapeCutoutPadding
  *
  * @param mediaList A list of [T]s.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun <T> MediaSmallRow(
     title: String?,
     mediaList: List<T>,
     modifier: Modifier = Modifier,
-    content: @Composable (T) -> Unit
+    content: @Composable (T, Modifier) -> Unit
 ) {
     Column(
         modifier = modifier,
@@ -63,8 +72,8 @@ fun <T> MediaSmallRow(
                     .landscapeCutoutPadding()
             )
         }
-        LazyRow(
-            horizontalArrangement = Arrangement.spacedBy(LocalPaddings.current.small),
+        HorizontalUncontainedCarousel(
+            state = rememberCarouselState { mediaList.count() },
             contentPadding = PaddingValues(
                 start = LocalPaddings.current.large + if (
                     LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
@@ -73,11 +82,13 @@ fun <T> MediaSmallRow(
                         .calculateLeftPadding(LayoutDirection.Ltr)
                 } else 0.dp,
                 end = LocalPaddings.current.large
+            ),
+            itemWidth = dimensionResource(R.dimen.media_card_width),
+            itemSpacing = LocalPaddings.current.small,
+        ) { index ->
+            content(mediaList[index], Modifier.maskClip(
+                RoundedCornerShape(dimensionResource(R.dimen.media_card_corner_radius)))
             )
-        ) {
-            items(mediaList) { media ->
-                content(media)
-            }
         }
     }
 }

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
@@ -44,13 +44,18 @@ private fun UserMediaList(
         modifier = modifier
     ) {
         lists.fastForEach {
-            MediaSmallRow(it.name, it.list, dimensionResource(coreR.dimen.media_card_width)) { media, _ ->
+            MediaSmallRow(
+                title = it.name,
+                mediaList = it.list,
+                mediaWidth = dimensionResource(coreR.dimen.media_card_width),
+            ) { media, clipModifier ->
                 MediaSmall(
                     image = media.coverImage,
                     label = media.title,
                     onClick = {},
                     imageHeight = dimensionResource(coreR.dimen.media_image_height),
                     cardWidth = dimensionResource(coreR.dimen.media_card_width),
+                    modifier = clipModifier,
                 )
             }
         }

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
@@ -44,7 +44,7 @@ private fun UserMediaList(
         modifier = modifier
     ) {
         lists.fastForEach {
-            MediaSmallRow(it.name, it.list) { media ->
+            MediaSmallRow(it.name, it.list) { media, _ ->
                 MediaSmall(
                     image = media.coverImage,
                     label = media.title,

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
@@ -44,7 +44,7 @@ private fun UserMediaList(
         modifier = modifier
     ) {
         lists.fastForEach {
-            MediaSmallRow(it.name, it.list) { media, _ ->
+            MediaSmallRow(it.name, it.list, dimensionResource(coreR.dimen.media_card_width)) { media, _ ->
                 MediaSmall(
                     image = media.coverImage,
                     label = media.title,


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

`HomeRow`s are now carousels.

**Summary of changes:**

1. `LazyRow` -> `HorizontalUncontainedCarousel`.

**Tested changes:**

Doesn't work as intended with shared element transitions.

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
