### PR TITLE
Navigate to `MediaPage` from `ProfileScreen`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin)
@@ -51,6 +53,12 @@ android {
 
 kotlin {
     jvmToolchain(21)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions.freeCompilerArgs.addAll(
+        "-opt-in=androidx.compose.animation.ExperimentalSharedTransitionApi"
+    )
 }
 
 dependencies {

--- a/app/src/main/kotlin/com/imashnake/animite/features/MainActivity.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/MainActivity.kt
@@ -92,7 +92,7 @@ fun MainScreen(modifier: Modifier = Modifier) {
                 NavHost(navController = navController, startDestination = HomeRoute) {
                     composable<HomeRoute> {
                         HomeScreen(
-                            onNavigateToMediaItem = { navController.navigate(it) },
+                            onNavigateToMediaItem = navController::navigate,
                             sharedTransitionScope = this@SharedTransitionLayout,
                             animatedVisibilityScope = this,
                         )
@@ -109,7 +109,7 @@ fun MainScreen(modifier: Modifier = Modifier) {
                         )
                     ) {
                         ProfileScreen(
-                            onNavigateToMediaItem = { navController.navigate(it) },
+                            onNavigateToMediaItem = navController::navigate,
                             sharedTransitionScope = this@SharedTransitionLayout,
                             animatedVisibilityScope = this,
                         )

--- a/app/src/main/kotlin/com/imashnake/animite/features/MainActivity.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/MainActivity.kt
@@ -108,7 +108,11 @@ fun MainScreen(modifier: Modifier = Modifier) {
                             navDeepLink { uriPattern = ANILIST_AUTH_DEEPLINK }
                         )
                     ) {
-                        ProfileScreen()
+                        ProfileScreen(
+                            onNavigateToMediaItem = { navController.navigate(it) },
+                            sharedTransitionScope = this@SharedTransitionLayout,
+                            animatedVisibilityScope = this,
+                        )
                     }
                     composable<SocialRoute> {
                         SocialScreen()

--- a/app/src/main/kotlin/com/imashnake/animite/features/MainActivity.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/MainActivity.kt
@@ -7,7 +7,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
@@ -68,7 +67,6 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun MainScreen(modifier: Modifier = Modifier) {
     val navController = rememberNavController()

--- a/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
@@ -5,7 +5,6 @@ import android.graphics.RuntimeShader
 import android.os.Build
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
@@ -89,7 +88,6 @@ import com.imashnake.animite.core.R as coreR
 import com.imashnake.animite.media.R as mediaR
 import com.imashnake.animite.navigation.R as navigationR
 
-@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 @Suppress("LongMethod")
 fun HomeScreen(
@@ -265,7 +263,6 @@ fun HomeScreen(
     }
 }
 
-@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun HomeRow(
     list: List<Media.Small>,

--- a/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
@@ -273,7 +273,7 @@ fun HomeRow(
     onItemClicked: (Media.Small) -> Unit,
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     MediaSmallRow(type.title, list, modifier) { media ->
         with(sharedTransitionScope) {

--- a/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
@@ -220,6 +220,7 @@ fun HomeScreen(
                                                     onNavigateToMediaItem(
                                                         MediaPage(
                                                             id = media.id,
+                                                            // TODO: We can use the list's index instead.
                                                             source = mediaList.type.name,
                                                             mediaType = homeMediaType.value.rawValue,
                                                         )

--- a/media/build.gradle.kts
+++ b/media/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin)
@@ -23,6 +25,12 @@ android {
 
 kotlin {
     jvmToolchain(21)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions.freeCompilerArgs.addAll(
+        "-opt-in=androidx.compose.animation.ExperimentalSharedTransitionApi"
+    )
 }
 
 dependencies {

--- a/media/src/main/kotlin/com/imashnake/animite/media/MediaPage.kt
+++ b/media/src/main/kotlin/com/imashnake/animite/media/MediaPage.kt
@@ -7,7 +7,6 @@ import android.text.method.LinkMovementMethod
 import android.util.Log
 import android.widget.TextView
 import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
@@ -92,7 +91,6 @@ import com.imashnake.animite.core.R as coreR
 // TODO: Need to use WindowInsets to get device corner radius if available.
 private const val DEVICE_CORNER_RADIUS = 30
 
-@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 @Suppress(
     "CognitiveComplexMethod",

--- a/profile/build.gradle.kts
+++ b/profile/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin)
@@ -22,6 +24,12 @@ android {
 
 kotlin {
     jvmToolchain(21)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions.freeCompilerArgs.addAll(
+        "-opt-in=androidx.compose.animation.ExperimentalSharedTransitionApi"
+    )
 }
 
 dependencies {

--- a/profile/build.gradle.kts
+++ b/profile/build.gradle.kts
@@ -25,10 +25,11 @@ kotlin {
 }
 
 dependencies {
-    implementation(projects.navigation)
-    implementation(projects.core)
     implementation(projects.api.anilist)
     implementation(projects.api.preferences)
+    implementation(projects.core)
+    implementation(projects.media)
+    implementation(projects.navigation)
 
     // AndroidX
     implementation(libs.androidx.activityCompose)

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -150,7 +150,7 @@ private fun UserDescription(description: String?, modifier: Modifier = Modifier)
                     ),
                     blockQuoteStyle = animiteBlockQuoteStyle(),
                     codeBlockStyle = animiteCodeBlockStyle(),
-                    modifier = contentModifier
+                    modifier = contentModifier,
                 )
             }
         }
@@ -165,10 +165,10 @@ private fun UserDescription(description: String?, modifier: Modifier = Modifier)
 private fun UserTabs(
     user: User,
     mediaCollection: User.MediaCollection?,
-    modifier: Modifier = Modifier,
     onNavigateToMediaItem: (MediaPage) -> Unit,
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope,
+    modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { ProfileTabs.entries.size })

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -1,7 +1,6 @@
 package com.imashnake.animite.profile
 
 import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -53,7 +52,6 @@ import kotlinx.coroutines.launch
 import com.imashnake.animite.core.R as coreR
 import com.imashnake.animite.navigation.R as navigationR
 
-@OptIn(ExperimentalSharedTransitionApi::class)
 @Suppress("LongMethod")
 @Composable
 fun ProfileScreen(
@@ -157,10 +155,7 @@ private fun UserDescription(description: String?, modifier: Modifier = Modifier)
     }
 }
 
-@OptIn(
-    ExperimentalMaterial3Api::class,
-    ExperimentalSharedTransitionApi::class,
-)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun UserTabs(
     user: User,

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -117,7 +117,10 @@ fun ProfileScreen(
                             Spacer(Modifier.size(LocalPaddings.current.medium))
                             UserTabs(
                                 user = this@run,
-                                mediaCollection = viewerMediaLists?.data
+                                mediaCollection = viewerMediaLists?.data,
+                                onNavigateToMediaItem = onNavigateToMediaItem,
+                                sharedTransitionScope = sharedTransitionScope,
+                                animatedVisibilityScope = animatedVisibilityScope,
                             )
                         }
                     },
@@ -154,12 +157,18 @@ private fun UserDescription(description: String?, modifier: Modifier = Modifier)
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(
+    ExperimentalMaterial3Api::class,
+    ExperimentalSharedTransitionApi::class,
+)
 @Composable
 private fun UserTabs(
     user: User,
     mediaCollection: User.MediaCollection?,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onNavigateToMediaItem: (MediaPage) -> Unit,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { ProfileTabs.entries.size })
@@ -215,7 +224,12 @@ private fun UserTabs(
             Box(Modifier.fillMaxSize()) {
                 when (ProfileTabs.entries[page]) {
                     ProfileTabs.ABOUT -> AboutTab(user)
-                    ProfileTabs.ANIME -> AnimeTab(mediaCollection)
+                    ProfileTabs.ANIME -> AnimeTab(
+                        mediaCollection = mediaCollection,
+                        onNavigateToMediaItem = onNavigateToMediaItem,
+                        sharedTransitionScope = sharedTransitionScope,
+                        animatedVisibilityScope = animatedVisibilityScope,
+                    )
                     else -> Text(
                         text = stringResource(coreR.string.coming_soon),
                         color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -1,5 +1,8 @@
 package com.imashnake.animite.profile
 
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -42,6 +45,7 @@ import com.imashnake.animite.core.extensions.maxHeight
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.NestedScrollableContent
 import com.imashnake.animite.core.ui.layouts.BannerLayout
+import com.imashnake.animite.media.MediaPage
 import com.imashnake.animite.profile.tabs.AboutTab
 import com.imashnake.animite.profile.tabs.AnimeTab
 import com.imashnake.animite.profile.tabs.ProfileTabs
@@ -49,9 +53,13 @@ import kotlinx.coroutines.launch
 import com.imashnake.animite.core.R as coreR
 import com.imashnake.animite.navigation.R as navigationR
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Suppress("LongMethod")
 @Composable
 fun ProfileScreen(
+    onNavigateToMediaItem: (MediaPage) -> Unit,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
     viewModel: ProfileViewModel = hiltViewModel(),
 ) {
     val isLoggedIn by viewModel.isLoggedIn.collectAsState(initial = false)

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -47,7 +47,7 @@ import com.imashnake.animite.core.ui.layouts.BannerLayout
 import com.imashnake.animite.media.MediaPage
 import com.imashnake.animite.profile.tabs.AboutTab
 import com.imashnake.animite.profile.tabs.AnimeTab
-import com.imashnake.animite.profile.tabs.ProfileTabs
+import com.imashnake.animite.profile.tabs.ProfileTab
 import kotlinx.coroutines.launch
 import com.imashnake.animite.core.R as coreR
 import com.imashnake.animite.navigation.R as navigationR
@@ -166,8 +166,8 @@ private fun UserTabs(
     modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val pagerState = rememberPagerState(pageCount = { ProfileTabs.entries.size })
-    val titles = ProfileTabs.entries
+    val pagerState = rememberPagerState(pageCount = { ProfileTab.entries.size })
+    val titles = ProfileTab.entries
     val onBackground = MaterialTheme.colorScheme.onBackground
 
     Column(modifier) {
@@ -217,9 +217,9 @@ private fun UserTabs(
                 )
         ) { page ->
             Box(Modifier.fillMaxSize()) {
-                when (ProfileTabs.entries[page]) {
-                    ProfileTabs.ABOUT -> AboutTab(user)
-                    ProfileTabs.ANIME -> AnimeTab(
+                when (ProfileTab.entries[page]) {
+                    ProfileTab.ABOUT -> AboutTab(user)
+                    ProfileTab.ANIME -> AnimeTab(
                         mediaCollection = mediaCollection,
                         onNavigateToMediaItem = onNavigateToMediaItem,
                         sharedTransitionScope = sharedTransitionScope,

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
@@ -17,6 +17,11 @@ import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.MediaSmall
 import com.imashnake.animite.core.ui.MediaSmallRow
 import com.imashnake.animite.media.MediaPage
+import com.imashnake.animite.navigation.SharedContentKey
+import com.imashnake.animite.navigation.SharedContentKey.Component.Card
+import com.imashnake.animite.navigation.SharedContentKey.Component.Image
+import com.imashnake.animite.navigation.SharedContentKey.Component.Page
+import com.imashnake.animite.navigation.SharedContentKey.Component.Text
 import com.imashnake.animite.core.R as coreR
 
 @Composable
@@ -61,22 +66,54 @@ private fun UserMediaList(
     ) {
         lists.fastForEach { namedList ->
             MediaSmallRow(namedList.name, namedList.list) { media ->
-                MediaSmall(
-                    image = media.coverImage,
-                    label = media.title,
-                    onClick = {
-                        onNavigateToMediaItem(
-                            MediaPage(
-                                id = media.id,
-                                // TODO: We can use the list's index instead.
-                                source = namedList.name.orEmpty(),
-                                mediaType = MediaType.ANIME.rawValue,
+                with(sharedTransitionScope) {
+                    MediaSmall(
+                        image = media.coverImage,
+                        label = media.title,
+                        onClick = {
+                            onNavigateToMediaItem(
+                                MediaPage(
+                                    id = media.id,
+                                    // TODO: We can use the list's index instead.
+                                    source = namedList.name.orEmpty(),
+                                    mediaType = MediaType.ANIME.rawValue,
+                                )
                             )
-                        )
-                    },
-                    imageHeight = dimensionResource(coreR.dimen.media_image_height),
-                    cardWidth = dimensionResource(coreR.dimen.media_card_width),
-                )
+                        },
+                        imageHeight = dimensionResource(coreR.dimen.media_image_height),
+                        cardWidth = dimensionResource(coreR.dimen.media_card_width),
+                        modifier = Modifier.sharedBounds(
+                            rememberSharedContentState(
+                                SharedContentKey(
+                                    id = media.id,
+                                    source = namedList.name,
+                                    sharedComponents = Card to Page,
+                                )
+                            ),
+                            animatedVisibilityScope
+                        ),
+                        imageModifier = Modifier.sharedBounds(
+                            rememberSharedContentState(
+                                SharedContentKey(
+                                    id = media.id,
+                                    source = namedList.name,
+                                    sharedComponents = Image to Image,
+                                )
+                            ),
+                            animatedVisibilityScope,
+                        ),
+                        textModifier = Modifier.sharedBounds(
+                            rememberSharedContentState(
+                                SharedContentKey(
+                                    id = media.id,
+                                    source = namedList.name,
+                                    sharedComponents = Text to Text,
+                                )
+                            ),
+                            animatedVisibilityScope,
+                        ),
+                    )
+                }
             }
         }
     }

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
@@ -1,7 +1,6 @@
 package com.imashnake.animite.profile.tabs
 
 import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -20,7 +19,6 @@ import com.imashnake.animite.core.ui.MediaSmallRow
 import com.imashnake.animite.media.MediaPage
 import com.imashnake.animite.core.R as coreR
 
-@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun AnimeTab(
     mediaCollection: User.MediaCollection?,
@@ -49,7 +47,6 @@ fun AnimeTab(
     }
 }
 
-@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 private fun UserMediaList(
     lists: List<User.MediaCollection.NamedList>,

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
@@ -1,5 +1,8 @@
 package com.imashnake.animite.profile.tabs
 
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -13,12 +16,17 @@ import com.imashnake.animite.api.anilist.sanitize.profile.User
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.MediaSmall
 import com.imashnake.animite.core.ui.MediaSmallRow
+import com.imashnake.animite.media.MediaPage
 import com.imashnake.animite.core.R as coreR
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun AnimeTab(
     mediaCollection: User.MediaCollection?,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onNavigateToMediaItem: (MediaPage) -> Unit,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
     val scrollState = rememberScrollState()
 

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
@@ -24,10 +24,10 @@ import com.imashnake.animite.core.R as coreR
 @Composable
 fun AnimeTab(
     mediaCollection: User.MediaCollection?,
-    modifier: Modifier = Modifier,
     onNavigateToMediaItem: (MediaPage) -> Unit,
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope,
+    modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
 
@@ -40,10 +40,10 @@ fun AnimeTab(
         if (!mediaCollection?.namedLists.isNullOrEmpty()) {
             UserMediaList(
                 lists =  mediaCollection!!.namedLists,
-                modifier = modifier,
                 onNavigateToMediaItem = onNavigateToMediaItem,
                 sharedTransitionScope = sharedTransitionScope,
                 animatedVisibilityScope = animatedVisibilityScope,
+                modifier = modifier,
             )
         }
     }
@@ -53,10 +53,10 @@ fun AnimeTab(
 @Composable
 private fun UserMediaList(
     lists: List<User.MediaCollection.NamedList>,
-    modifier: Modifier = Modifier,
     onNavigateToMediaItem: (MediaPage) -> Unit,
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(LocalPaddings.current.large),

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
@@ -59,8 +59,8 @@ private fun UserMediaList(
         verticalArrangement = Arrangement.spacedBy(LocalPaddings.current.large),
         modifier = modifier
     ) {
-        lists.fastForEach {
-            MediaSmallRow(it.name, it.list) { media ->
+        lists.fastForEach { namedList ->
+            MediaSmallRow(namedList.name, namedList.list) { media ->
                 MediaSmall(
                     image = media.coverImage,
                     label = media.title,
@@ -68,8 +68,8 @@ private fun UserMediaList(
                         onNavigateToMediaItem(
                             MediaPage(
                                 id = media.id,
-                                // TODO: Unhardcode these and make them unique.
-                                source = media.title.orEmpty(),
+                                // TODO: We can use the list's index instead.
+                                source = namedList.name.orEmpty(),
                                 mediaType = MediaType.ANIME.rawValue,
                             )
                         )

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Anime.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.util.fastForEach
 import com.imashnake.animite.api.anilist.sanitize.profile.User
+import com.imashnake.animite.api.anilist.type.MediaType
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.MediaSmall
 import com.imashnake.animite.core.ui.MediaSmallRow
@@ -37,15 +38,25 @@ fun AnimeTab(
     ) {
         // TODO: Why is this not smart-casting?
         if (!mediaCollection?.namedLists.isNullOrEmpty()) {
-            UserMediaList(mediaCollection!!.namedLists, modifier)
+            UserMediaList(
+                lists =  mediaCollection!!.namedLists,
+                modifier = modifier,
+                onNavigateToMediaItem = onNavigateToMediaItem,
+                sharedTransitionScope = sharedTransitionScope,
+                animatedVisibilityScope = animatedVisibilityScope,
+            )
         }
     }
 }
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 private fun UserMediaList(
     lists: List<User.MediaCollection.NamedList>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onNavigateToMediaItem: (MediaPage) -> Unit,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(LocalPaddings.current.large),
@@ -56,7 +67,16 @@ private fun UserMediaList(
                 MediaSmall(
                     image = media.coverImage,
                     label = media.title,
-                    onClick = {},
+                    onClick = {
+                        onNavigateToMediaItem(
+                            MediaPage(
+                                id = media.id,
+                                // TODO: Unhardcode these and make them unique.
+                                source = media.title.orEmpty(),
+                                mediaType = MediaType.ANIME.rawValue,
+                            )
+                        )
+                    },
                     imageHeight = dimensionResource(coreR.dimen.media_image_height),
                     cardWidth = dimensionResource(coreR.dimen.media_card_width),
                 )

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/ProfileTab.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/ProfileTab.kt
@@ -3,7 +3,7 @@ package com.imashnake.animite.profile.tabs
 import androidx.annotation.StringRes
 import com.imashnake.animite.profile.R
 
-enum class ProfileTabs(@StringRes val titleRes: Int) {
+enum class ProfileTab(@StringRes val titleRes: Int) {
     ABOUT(R.string.about),
     ANIME(R.string.anime),
     MANGA(R.string.manga),


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Now that #232 is merged, we can navigate to media pages from the profile screen.

**Summary of changes:**

1. Propagate required params and add callback.

**Tested changes:**

Navigation works 👍 

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
