### PR TITLE
Profile Screen Loading and Media Tab Fallback

### DIFF
--- a/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/AnilistUserRepository.kt
+++ b/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/AnilistUserRepository.kt
@@ -38,5 +38,5 @@ class AnilistUserRepository @Inject constructor(
             )
             .fetchPolicy(FetchPolicy.CacheFirst)
             .toFlow()
-            .asResult { User.MediaCollection(it) }
+            .asResult { User.MediaCollection(it, type) }
 }

--- a/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/sanitize/profile/Viewer.kt
+++ b/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/sanitize/profile/Viewer.kt
@@ -3,6 +3,8 @@ package com.imashnake.animite.api.anilist.sanitize.profile
 import com.imashnake.animite.api.anilist.UserMediaListQuery
 import com.imashnake.animite.api.anilist.fragment.User
 import com.imashnake.animite.api.anilist.sanitize.media.Media
+import com.imashnake.animite.api.anilist.sanitize.media.Media.Small.Type
+import com.imashnake.animite.api.anilist.type.MediaType
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.DurationUnit
 
@@ -60,7 +62,10 @@ data class User(
         val mediaCount: Int,
     )
 
-    data class MediaCollection(val namedLists: List<NamedList>) {
+    data class MediaCollection(
+        val type: Type,
+        val namedLists: List<NamedList>,
+    ) {
         data class NamedList(
             val name: String?,
             val list: List<Any>,
@@ -94,7 +99,8 @@ data class User(
             )
         }
 
-        internal constructor(query: UserMediaListQuery.Data) : this(
+        internal constructor(query: UserMediaListQuery.Data, type: MediaType?) : this(
+            type = type?.name?.let { Type.valueOf(it) } ?: Type.UNKNOWN,
             namedLists = query.mediaListCollection?.lists.orEmpty().mapNotNull {
                 NamedList(it ?: return@mapNotNull null)
             }

--- a/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
@@ -257,9 +257,7 @@ fun HomeScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(MaterialTheme.colorScheme.background)
-            ) {
-                ProgressIndicator()
-            }
+            ) { ProgressIndicator() }
         }
     }
 }

--- a/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
@@ -74,6 +74,7 @@ import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.MediaSmall
 import com.imashnake.animite.core.ui.MediaSmallRow
 import com.imashnake.animite.core.ui.ProgressIndicator
+import com.imashnake.animite.core.ui.ProgressIndicatorScreen
 import com.imashnake.animite.core.ui.layouts.BannerLayout
 import com.imashnake.animite.core.ui.layouts.TranslucentStatusBarLayout
 import com.imashnake.animite.core.ui.shaders.etherealShader
@@ -250,15 +251,7 @@ fun HomeScreen(
                 }
             }
         }
-
-        else -> {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background)
-            ) { ProgressIndicator() }
-        }
+        else -> ProgressIndicatorScreen()
     }
 }
 

--- a/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -73,7 +72,6 @@ import com.imashnake.animite.core.extensions.thenIf
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.MediaSmall
 import com.imashnake.animite.core.ui.MediaSmallRow
-import com.imashnake.animite.core.ui.ProgressIndicator
 import com.imashnake.animite.core.ui.ProgressIndicatorScreen
 import com.imashnake.animite.core.ui.layouts.BannerLayout
 import com.imashnake.animite.core.ui.layouts.TranslucentStatusBarLayout

--- a/core/src/main/kotlin/com/imashnake/animite/core/ui/ProgressIndicator.kt
+++ b/core/src/main/kotlin/com/imashnake/animite/core/ui/ProgressIndicator.kt
@@ -27,9 +27,9 @@ fun ProgressIndicatorScreen(modifier: Modifier = Modifier) {
 @Composable
 private fun ProgressIndicator() {
     LinearProgressIndicator(
+        strokeCap = StrokeCap.Round,
         modifier = Modifier
             .width(dimensionResource(R.dimen.progress_indicator_width))
             .height(dimensionResource(R.dimen.progress_indicator_height)),
-        strokeCap = StrokeCap.Round
     )
 }

--- a/core/src/main/kotlin/com/imashnake/animite/core/ui/ProgressIndicator.kt
+++ b/core/src/main/kotlin/com/imashnake/animite/core/ui/ProgressIndicator.kt
@@ -25,7 +25,7 @@ fun ProgressIndicatorScreen(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun ProgressIndicator() {
+private fun ProgressIndicator() {
     LinearProgressIndicator(
         modifier = Modifier
             .width(dimensionResource(R.dimen.progress_indicator_width))

--- a/core/src/main/kotlin/com/imashnake/animite/core/ui/ProgressIndicator.kt
+++ b/core/src/main/kotlin/com/imashnake/animite/core/ui/ProgressIndicator.kt
@@ -1,13 +1,28 @@
 package com.imashnake.animite.core.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.res.dimensionResource
 import com.imashnake.animite.core.R
+
+@Composable
+fun ProgressIndicatorScreen(modifier: Modifier = Modifier) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) { ProgressIndicator() }
+}
 
 @Composable
 fun ProgressIndicator() {

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -243,7 +243,7 @@ private fun UserTabs(
                         )
                     }
                     ProfileTab.MANGA -> when {
-                        animeCollection?.namedLists?.isEmpty() == true -> {
+                        mangaCollection?.namedLists?.isEmpty() == true -> {
                             FallbackScreen(stringResource(R.string.no_manga))
                         }
                         else -> MediaTab(

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -43,6 +43,7 @@ import com.imashnake.animite.core.extensions.crossfadeModel
 import com.imashnake.animite.core.extensions.landscapeCutoutPadding
 import com.imashnake.animite.core.extensions.maxHeight
 import com.imashnake.animite.core.ui.FallbackMessage
+import com.imashnake.animite.core.ui.FallbackScreen
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.NestedScrollableContent
 import com.imashnake.animite.core.ui.ProgressIndicatorScreen
@@ -229,18 +230,29 @@ private fun UserTabs(
             Box(Modifier.fillMaxSize()) {
                 when (ProfileTab.entries[page]) {
                     ProfileTab.ABOUT -> AboutTab(user)
-                    ProfileTab.ANIME -> MediaTab(
-                        mediaCollection = animeCollection,
-                        onNavigateToMediaItem = onNavigateToMediaItem,
-                        sharedTransitionScope = sharedTransitionScope,
-                        animatedVisibilityScope = animatedVisibilityScope,
-                    )
-                    ProfileTab.MANGA -> MediaTab(
-                        mediaCollection = mangaCollection,
-                        onNavigateToMediaItem = onNavigateToMediaItem,
-                        sharedTransitionScope = sharedTransitionScope,
-                        animatedVisibilityScope = animatedVisibilityScope,
-                    )
+                    // TODO: This fallback duplication can probably be moved to `MediaTab`.
+                    ProfileTab.ANIME -> when {
+                        animeCollection?.namedLists?.isEmpty() == true -> {
+                            FallbackScreen(stringResource(R.string.no_anime))
+                        }
+                        else -> MediaTab(
+                            mediaCollection = animeCollection,
+                            onNavigateToMediaItem = onNavigateToMediaItem,
+                            sharedTransitionScope = sharedTransitionScope,
+                            animatedVisibilityScope = animatedVisibilityScope,
+                        )
+                    }
+                    ProfileTab.MANGA -> when {
+                        animeCollection?.namedLists?.isEmpty() == true -> {
+                            FallbackScreen(stringResource(R.string.no_manga))
+                        }
+                        else -> MediaTab(
+                            mediaCollection = mangaCollection,
+                            onNavigateToMediaItem = onNavigateToMediaItem,
+                            sharedTransitionScope = sharedTransitionScope,
+                            animatedVisibilityScope = animatedVisibilityScope,
+                        )
+                    }
                     ProfileTab.FAVOURITES -> FavouritesTab(user.favourites)
                     else -> FallbackMessage(
                         message = stringResource(coreR.string.coming_soon),

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -230,29 +230,18 @@ private fun UserTabs(
             Box(Modifier.fillMaxSize()) {
                 when (ProfileTab.entries[page]) {
                     ProfileTab.ABOUT -> AboutTab(user)
-                    // TODO: This fallback duplication can probably be moved to `MediaTab`.
-                    ProfileTab.ANIME -> when {
-                        animeCollection?.namedLists?.isEmpty() == true -> {
-                            FallbackScreen(stringResource(R.string.no_anime))
-                        }
-                        else -> MediaTab(
-                            mediaCollection = animeCollection,
-                            onNavigateToMediaItem = onNavigateToMediaItem,
-                            sharedTransitionScope = sharedTransitionScope,
-                            animatedVisibilityScope = animatedVisibilityScope,
-                        )
-                    }
-                    ProfileTab.MANGA -> when {
-                        mangaCollection?.namedLists?.isEmpty() == true -> {
-                            FallbackScreen(stringResource(R.string.no_manga))
-                        }
-                        else -> MediaTab(
-                            mediaCollection = mangaCollection,
-                            onNavigateToMediaItem = onNavigateToMediaItem,
-                            sharedTransitionScope = sharedTransitionScope,
-                            animatedVisibilityScope = animatedVisibilityScope,
-                        )
-                    }
+                    ProfileTab.ANIME -> MediaTab(
+                        mediaCollection = animeCollection,
+                        onNavigateToMediaItem = onNavigateToMediaItem,
+                        sharedTransitionScope = sharedTransitionScope,
+                        animatedVisibilityScope = animatedVisibilityScope,
+                    )
+                    ProfileTab.MANGA -> MediaTab(
+                        mediaCollection = mangaCollection,
+                        onNavigateToMediaItem = onNavigateToMediaItem,
+                        sharedTransitionScope = sharedTransitionScope,
+                        animatedVisibilityScope = animatedVisibilityScope,
+                    )
                     ProfileTab.FAVOURITES -> FavouritesTab(user.favourites)
                     else -> FallbackMessage(
                         message = stringResource(coreR.string.coming_soon),

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -36,6 +36,7 @@ import coil3.compose.AsyncImage
 import com.boswelja.markdown.material3.MarkdownDocument
 import com.boswelja.markdown.material3.m3TextStyles
 import com.imashnake.animite.api.anilist.sanitize.profile.User
+import com.imashnake.animite.core.data.Resource
 import com.imashnake.animite.core.extensions.animiteBlockQuoteStyle
 import com.imashnake.animite.core.extensions.animiteCodeBlockStyle
 import com.imashnake.animite.core.extensions.crossfadeModel
@@ -44,6 +45,7 @@ import com.imashnake.animite.core.extensions.maxHeight
 import com.imashnake.animite.core.ui.FallbackMessage
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.NestedScrollableContent
+import com.imashnake.animite.core.ui.ProgressIndicator
 import com.imashnake.animite.core.ui.layouts.BannerLayout
 import com.imashnake.animite.media.MediaPage
 import com.imashnake.animite.profile.tabs.AboutTab
@@ -64,8 +66,10 @@ fun ProfileScreen(
 ) {
     val isLoggedIn by viewModel.isLoggedIn.collectAsState(initial = false)
     val viewer by viewModel.viewer.collectAsState()
-    val viewerAnimeLists by viewModel.viewerAnimeLists.collectAsState(initial = null)
-    val viewerMangaLists by viewModel.viewerMangaLists.collectAsState(initial = null)
+    val viewerAnimeLists by viewModel.viewerAnimeLists.collectAsState()
+    val viewerMangaLists by viewModel.viewerMangaLists.collectAsState()
+
+    val data = listOf(viewer, viewerAnimeLists, viewerMangaLists)
 
     Box(
         contentAlignment = Alignment.Center,
@@ -74,63 +78,71 @@ fun ProfileScreen(
             .background(MaterialTheme.colorScheme.background)
     ) {
         when {
-            isLoggedIn -> viewer.data?.run {
-                BannerLayout(
-                    banner = {
-                        Box {
-                            AsyncImage(
-                                model = crossfadeModel(banner),
-                                contentDescription = "banner",
-                                modifier = it,
-                                contentScale = ContentScale.Crop
-                            )
-                            AsyncImage(
-                                model = crossfadeModel(avatar),
-                                contentDescription = "avatar",
-                                modifier = Modifier
-                                    .align(Alignment.BottomStart)
-                                    .landscapeCutoutPadding()
-                                    .padding(start = LocalPaddings.current.medium)
-                                    .size(100.dp)
-                            )
-                        }
-                    },
-                    content = {
-                        Column {
-                            Text(
-                                text = name,
-                                color = MaterialTheme.colorScheme.onBackground,
-                                style = MaterialTheme.typography.titleLarge,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier
-                                    .padding(
-                                        horizontal = LocalPaddings.current.large
-                                    )
-                                    .landscapeCutoutPadding()
-                            )
-                            UserDescription(
-                                description = description,
-                                modifier = Modifier
-                                    .maxHeight(dimensionResource(R.dimen.user_about_height))
-                                    .padding(horizontal = LocalPaddings.current.large)
-                                    .landscapeCutoutPadding()
-                            )
-                            Spacer(Modifier.size(LocalPaddings.current.medium))
-                            UserTabs(
-                                user = this@run,
-                                animeCollection = viewerAnimeLists?.data,
-                                mangaCollection = viewerMangaLists?.data,
-                                onNavigateToMediaItem = onNavigateToMediaItem,
-                                sharedTransitionScope = sharedTransitionScope,
-                                animatedVisibilityScope = animatedVisibilityScope,
-                            )
-                        }
-                    },
-                    contentModifier = Modifier.padding(
-                        top = LocalPaddings.current.large,
-                        bottom = dimensionResource(navigationR.dimen.navigation_bar_height)
+            isLoggedIn -> when {
+                data.all { it is Resource.Success } -> viewer.data?.run {
+                    BannerLayout(
+                        banner = {
+                            Box {
+                                AsyncImage(
+                                    model = crossfadeModel(banner),
+                                    contentDescription = "banner",
+                                    modifier = it,
+                                    contentScale = ContentScale.Crop
+                                )
+                                AsyncImage(
+                                    model = crossfadeModel(avatar),
+                                    contentDescription = "avatar",
+                                    modifier = Modifier
+                                        .align(Alignment.BottomStart)
+                                        .landscapeCutoutPadding()
+                                        .padding(start = LocalPaddings.current.medium)
+                                        .size(100.dp)
+                                )
+                            }
+                        },
+                        content = {
+                            Column {
+                                Text(
+                                    text = name,
+                                    color = MaterialTheme.colorScheme.onBackground,
+                                    style = MaterialTheme.typography.titleLarge,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier
+                                        .padding(horizontal = LocalPaddings.current.large)
+                                        .landscapeCutoutPadding()
+                                )
+                                UserDescription(
+                                    description = description,
+                                    modifier = Modifier
+                                        .maxHeight(dimensionResource(R.dimen.user_about_height))
+                                        .padding(horizontal = LocalPaddings.current.large)
+                                        .landscapeCutoutPadding()
+                                )
+                                Spacer(Modifier.size(LocalPaddings.current.medium))
+                                UserTabs(
+                                    user = this@run,
+                                    animeCollection = viewerAnimeLists.data,
+                                    mangaCollection = viewerMangaLists.data,
+                                    onNavigateToMediaItem = onNavigateToMediaItem,
+                                    sharedTransitionScope = sharedTransitionScope,
+                                    animatedVisibilityScope = animatedVisibilityScope,
+                                )
+                            }
+                        },
+                        contentModifier = Modifier.padding(
+                            top = LocalPaddings.current.large,
+                            bottom = dimensionResource(navigationR.dimen.navigation_bar_height)
+                        )
                     )
-                )
+                }
+                else -> {
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(MaterialTheme.colorScheme.background)
+                    ) { ProgressIndicator() }
+                }
             }
             else -> Login()
         }

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -46,6 +46,7 @@ import com.imashnake.animite.core.ui.FallbackMessage
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.NestedScrollableContent
 import com.imashnake.animite.core.ui.ProgressIndicator
+import com.imashnake.animite.core.ui.ProgressIndicatorScreen
 import com.imashnake.animite.core.ui.layouts.BannerLayout
 import com.imashnake.animite.media.MediaPage
 import com.imashnake.animite.profile.tabs.AboutTab
@@ -135,14 +136,7 @@ fun ProfileScreen(
                         )
                     )
                 }
-                else -> {
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(MaterialTheme.colorScheme.background)
-                    ) { ProgressIndicator() }
-                }
+                else -> ProgressIndicatorScreen()
             }
             else -> Login()
         }

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -45,7 +45,6 @@ import com.imashnake.animite.core.extensions.maxHeight
 import com.imashnake.animite.core.ui.FallbackMessage
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.NestedScrollableContent
-import com.imashnake.animite.core.ui.ProgressIndicator
 import com.imashnake.animite.core.ui.ProgressIndicatorScreen
 import com.imashnake.animite.core.ui.layouts.BannerLayout
 import com.imashnake.animite.media.MediaPage

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileViewModel.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileViewModel.kt
@@ -39,9 +39,7 @@ class ProfileViewModel @Inject constructor(
         .fetchViewer()
         .asResource()
         .onEach {
-            it.data?.let {
-                preferencesRepository.setViewerId(it.id)
-            }
+            it.data?.let { user -> preferencesRepository.setViewerId(user.id) }
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(1000), Resource.loading())
 
@@ -49,15 +47,13 @@ class ProfileViewModel @Inject constructor(
         userRepository
             .fetchUserMediaList(it?.toIntOrNull(), MediaType.ANIME)
             .asResource()
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(1000), Resource.loading())
-    }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(1000), Resource.loading())
 
     val viewerMangaLists = preferencesRepository.viewerId.flatMapLatest {
         userRepository
             .fetchUserMediaList(it?.toIntOrNull(), MediaType.MANGA)
             .asResource()
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(1000), Resource.loading())
-    }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(1000), Resource.loading())
 
     init {
         if (navArgs.accessToken != null) {

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Media.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Media.kt
@@ -68,7 +68,7 @@ private fun UserMediaLists(
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(LocalPaddings.current.large),
-        modifier = modifier
+        modifier = modifier,
     ) {
         lists.fastForEach { namedList ->
             MediaSmallRow(namedList.name, namedList.list) { item ->

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Media.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Media.kt
@@ -10,9 +10,11 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.util.fastForEach
 import com.imashnake.animite.api.anilist.sanitize.media.Media
 import com.imashnake.animite.api.anilist.sanitize.profile.User
+import com.imashnake.animite.core.ui.FallbackScreen
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.MediaSmall
 import com.imashnake.animite.core.ui.MediaSmallRow
@@ -22,6 +24,7 @@ import com.imashnake.animite.navigation.SharedContentKey.Component.Card
 import com.imashnake.animite.navigation.SharedContentKey.Component.Image
 import com.imashnake.animite.navigation.SharedContentKey.Component.Page
 import com.imashnake.animite.navigation.SharedContentKey.Component.Text
+import com.imashnake.animite.profile.R
 import com.imashnake.animite.core.R as coreR
 
 /**
@@ -40,20 +43,33 @@ fun MediaTab(
 ) {
     val scrollState = rememberScrollState()
 
-    Column(
-        modifier
-            .verticalScroll(scrollState)
-            .padding(vertical = LocalPaddings.current.large)
-    ) {
-        // TODO: Why is this not smart-casting?
-        if (!mediaCollection?.namedLists.isNullOrEmpty()) {
-            UserMediaLists(
-                lists =  mediaCollection!!.namedLists,
-                onNavigateToMediaItem = onNavigateToMediaItem,
-                sharedTransitionScope = sharedTransitionScope,
-                animatedVisibilityScope = animatedVisibilityScope,
-                modifier = modifier,
+    when {
+        mediaCollection?.namedLists?.isEmpty() == true -> {
+            FallbackScreen(
+                stringResource(
+                    when (mediaCollection.type) {
+                        Media.Small.Type.ANIME -> R.string.no_anime
+                        Media.Small.Type.MANGA -> R.string.no_manga
+                        Media.Small.Type.UNKNOWN -> R.string.no_media
+                    }
+                )
             )
+        }
+        else -> Column(
+            modifier
+                .verticalScroll(scrollState)
+                .padding(vertical = LocalPaddings.current.large)
+        ) {
+            // TODO: Why is this not smart-casting?
+            if (!mediaCollection?.namedLists.isNullOrEmpty()) {
+                UserMediaLists(
+                    lists =  mediaCollection!!.namedLists,
+                    onNavigateToMediaItem = onNavigateToMediaItem,
+                    sharedTransitionScope = sharedTransitionScope,
+                    animatedVisibilityScope = animatedVisibilityScope,
+                    modifier = modifier,
+                )
+            }
         }
     }
 }

--- a/profile/src/main/res/values/strings.xml
+++ b/profile/src/main/res/values/strings.xml
@@ -14,5 +14,6 @@
 
     <string name="no_anime">No Anime</string>
     <string name="no_manga">No Manga</string>
+    <string name="no_media">No Media</string>
     <string name="no_favourites">No Favourites</string>
 </resources>

--- a/profile/src/main/res/values/strings.xml
+++ b/profile/src/main/res/values/strings.xml
@@ -12,5 +12,7 @@
 
     <string name="genres">Genres</string>
 
+    <string name="no_anime">No Anime</string>
+    <string name="no_manga">No Manga</string>
     <string name="no_favourites">No Favourites</string>
 </resources>


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

This adds a progress indicator for when the profile screen is loading and "No <Media>" fallback text to profile media tabs.

**Summary of changes:**

1. Linear progress indicator is shown on profile screen when it's loading.
2. Fallback text is shown on profile media tabs when there are no media collections.

**Tested changes:**

HMMMMMMM

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
