### PR TITLE
Hide MediaSmall behind MediaCard and CharacterCard

### DIFF
--- a/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
@@ -70,7 +70,7 @@ import com.imashnake.animite.core.extensions.bannerParallax
 import com.imashnake.animite.core.extensions.landscapeCutoutPadding
 import com.imashnake.animite.core.extensions.thenIf
 import com.imashnake.animite.core.ui.LocalPaddings
-import com.imashnake.animite.core.ui.MediaSmall
+import com.imashnake.animite.core.ui.MediaCard
 import com.imashnake.animite.core.ui.MediaSmallRow
 import com.imashnake.animite.core.ui.ProgressIndicatorScreen
 import com.imashnake.animite.core.ui.layouts.BannerLayout
@@ -83,7 +83,6 @@ import com.imashnake.animite.navigation.SharedContentKey.Component.Image
 import com.imashnake.animite.navigation.SharedContentKey.Component.Page
 import com.imashnake.animite.navigation.SharedContentKey.Component.Text
 import com.materialkolor.ktx.hasEnoughContrast
-import com.imashnake.animite.core.R as coreR
 import com.imashnake.animite.media.R as mediaR
 import com.imashnake.animite.navigation.R as navigationR
 
@@ -264,12 +263,10 @@ fun HomeRow(
 ) {
     MediaSmallRow(type.title, list, modifier) { media ->
         with(sharedTransitionScope) {
-            MediaSmall(
+            MediaCard(
                 image = media.coverImage,
                 label = media.title,
                 onClick = { onItemClicked(media) },
-                imageHeight = dimensionResource(coreR.dimen.media_image_height),
-                cardWidth = dimensionResource(coreR.dimen.media_card_width),
                 modifier = Modifier.sharedBounds(
                     rememberSharedContentState(
                         SharedContentKey(

--- a/app/src/main/kotlin/com/imashnake/animite/features/searchbar/SearchFrontDrop.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/searchbar/SearchFrontDrop.kt
@@ -47,9 +47,8 @@ import com.imashnake.animite.api.anilist.type.MediaType
 import com.imashnake.animite.core.Constants
 import com.imashnake.animite.core.extensions.landscapeCutoutPadding
 import com.imashnake.animite.core.ui.LocalPaddings
-import com.imashnake.animite.core.ui.MediaSmall
+import com.imashnake.animite.core.ui.MediaCard
 import com.imashnake.animite.core.R as coreR
-import com.imashnake.animite.media.R as mediaR
 import com.imashnake.animite.navigation.R as navigationR
 
 /**
@@ -165,11 +164,10 @@ private fun SearchItem(
             .clip(RoundedCornerShape(dimensionResource(coreR.dimen.media_card_corner_radius)))
             .clickable { onClick(item.id) }
     ) {
-        MediaSmall(
+        MediaCard(
             image = item.coverImage,
+            label = null,
             onClick = { onClick(item.id) },
-            imageHeight = dimensionResource(mediaR.dimen.character_image_height),
-            cardWidth = dimensionResource(mediaR.dimen.character_card_width),
         )
 
         Column(Modifier.padding(horizontal = LocalPaddings.current.small)) {

--- a/core/src/main/kotlin/com/imashnake/animite/core/ui/MediaSmall.kt
+++ b/core/src/main/kotlin/com/imashnake/animite/core/ui/MediaSmall.kt
@@ -82,6 +82,62 @@ fun <T> MediaSmallRow(
 }
 
 /**
+ * A [Card] that displays media (anime or manga) thumbnail, and an optional label.
+ *
+ * @param image A URL of the image to be shown in the card that this component is.
+ * @param label A label for the [image], if this is `null`, the [label] is not shown.
+ * @param onClick Action to happen when the card is clicked.
+ */
+@Composable
+fun MediaCard(
+    image: String?,
+    label: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    imageModifier: Modifier = Modifier,
+    textModifier: Modifier = Modifier,
+) {
+    MediaSmall(
+        image = image,
+        onClick = onClick,
+        imageHeight = 200.dp,
+        cardWidth = 140.dp,
+        modifier = modifier,
+        imageModifier = imageModifier,
+        textModifier = textModifier,
+        label = label
+    )
+}
+
+/**
+ * A [Card] that displays a character thumbnail, and an optional label.
+ *
+ * @param image A URL of the image to be shown in the card that this component is.
+ * @param label A label for the [image], if this is `null`, the [label] is not shown.
+ * @param onClick Action to happen when the card is clicked.
+ */
+@Composable
+fun CharacterCard(
+    image: String?,
+    label: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    imageModifier: Modifier = Modifier,
+    textModifier: Modifier = Modifier,
+) {
+    MediaSmall(
+        image = image,
+        onClick = onClick,
+        imageHeight = 137.dp,
+        cardWidth = 96.dp,
+        modifier = modifier,
+        imageModifier = imageModifier,
+        textModifier = textModifier,
+        label = label
+    )
+}
+
+/**
  * A [Card] to display a media image and a label. Note that [imageHeight] and [cardWidth] must be
  * set so that all cards have the same dimensions.
  *
@@ -92,15 +148,15 @@ fun <T> MediaSmallRow(
  * @param cardWidth Width of the card.
  */
 @Composable
-fun MediaSmall(
+internal fun MediaSmall(
     image: String?,
+    label: String?,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
     imageHeight: Dp,
     cardWidth: Dp,
+    modifier: Modifier = Modifier,
     imageModifier: Modifier = Modifier,
     textModifier: Modifier = Modifier,
-    label: String? = null,
 ) {
     Card(
         onClick = onClick,

--- a/media/src/main/kotlin/com/imashnake/animite/media/MediaPage.kt
+++ b/media/src/main/kotlin/com/imashnake/animite/media/MediaPage.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
@@ -73,8 +74,9 @@ import com.imashnake.animite.core.Constants
 import com.imashnake.animite.core.extensions.bannerParallax
 import com.imashnake.animite.core.extensions.crossfadeModel
 import com.imashnake.animite.core.extensions.landscapeCutoutPadding
+import com.imashnake.animite.core.ui.CharacterCard
 import com.imashnake.animite.core.ui.LocalPaddings
-import com.imashnake.animite.core.ui.MediaSmall
+import com.imashnake.animite.core.ui.MediaCard
 import com.imashnake.animite.core.ui.MediaSmallRow
 import com.imashnake.animite.core.ui.NestedScrollableContent
 import com.imashnake.animite.core.ui.StatsRow
@@ -87,7 +89,6 @@ import com.imashnake.animite.navigation.SharedContentKey.Component.Page
 import com.imashnake.animite.navigation.SharedContentKey.Component.Text
 import kotlinx.serialization.Serializable
 import com.imashnake.animite.core.R as coreR
-import androidx.core.net.toUri
 
 // TODO: Need to use WindowInsets to get device corner radius if available.
 private const val DEVICE_CORNER_RADIUS = 30
@@ -264,11 +265,10 @@ fun MediaPage(
                             .landscapeCutoutPadding()
                             .height(dimensionResource(coreR.dimen.media_image_height) - offset)
                     ) {
-                        MediaSmall(
+                        MediaCard(
                             image = media.coverImage,
+                            label = null,
                             onClick = {},
-                            imageHeight = dimensionResource(coreR.dimen.media_image_height),
-                            cardWidth = dimensionResource(coreR.dimen.media_card_width),
                             modifier = Modifier.sharedBounds(
                                 rememberSharedContentState(
                                     SharedContentKey(
@@ -423,12 +423,10 @@ fun MediaCharacters(
         mediaList = characters,
         modifier = modifier
     ) { character ->
-        MediaSmall(
+        CharacterCard(
             image = character.image,
             label = character.name,
             onClick = { Log.d("CharacterId", "${character.id}") },
-            imageHeight = dimensionResource(R.dimen.character_image_height),
-            cardWidth = dimensionResource(R.dimen.character_card_width),
         )
     }
 }

--- a/media/src/main/res/values/dimens.xml
+++ b/media/src/main/res/values/dimens.xml
@@ -9,8 +9,5 @@
     <dimen name="media_type_choice_size">36dp</dimen>
     <dimen name="media_type_selector_round">32dp</dimen>
 
-    <dimen name="character_card_width">96dp</dimen>
-    <dimen name="character_image_height">137dp</dimen>
-
     <dimen name="trailer_corner_radius">30dp</dimen>
 </resources>

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Favourites.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Favourites.kt
@@ -8,18 +8,16 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.util.fastForEach
 import com.imashnake.animite.api.anilist.sanitize.media.Media
 import com.imashnake.animite.api.anilist.sanitize.profile.User.MediaCollection.NamedList
+import com.imashnake.animite.core.ui.CharacterCard
 import com.imashnake.animite.core.ui.FallbackScreen
 import com.imashnake.animite.core.ui.LocalPaddings
-import com.imashnake.animite.core.ui.MediaSmall
+import com.imashnake.animite.core.ui.MediaCard
 import com.imashnake.animite.core.ui.MediaSmallRow
 import com.imashnake.animite.profile.R
-import com.imashnake.animite.media.R as mediaR
-import com.imashnake.animite.core.R as coreR
 
 /**
  * The viewer's favourite Anime, Manga, and Characters.
@@ -56,21 +54,17 @@ private fun UserFavouriteLists(
             MediaSmallRow(namedList.name, namedList.list) { item ->
                 when(item) {
                     is Media.Small -> {
-                        MediaSmall(
+                        MediaCard(
                             image = item.coverImage,
                             label = item.title,
                             onClick = {},
-                            imageHeight = dimensionResource(coreR.dimen.media_image_height),
-                            cardWidth = dimensionResource(coreR.dimen.media_card_width),
                         )
                     }
                     is Media.Character -> {
-                        MediaSmall(
+                        CharacterCard(
                             image = item.image,
                             label = item.name,
                             onClick = { Log.d("CharacterId", "${item.id}") },
-                            imageHeight = dimensionResource(mediaR.dimen.character_image_height),
-                            cardWidth = dimensionResource(mediaR.dimen.character_card_width),
                         )
                     }
                 }

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Media.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Media.kt
@@ -9,14 +9,13 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.util.fastForEach
 import com.imashnake.animite.api.anilist.sanitize.media.Media
 import com.imashnake.animite.api.anilist.sanitize.profile.User
 import com.imashnake.animite.core.ui.FallbackScreen
 import com.imashnake.animite.core.ui.LocalPaddings
-import com.imashnake.animite.core.ui.MediaSmall
+import com.imashnake.animite.core.ui.MediaCard
 import com.imashnake.animite.core.ui.MediaSmallRow
 import com.imashnake.animite.media.MediaPage
 import com.imashnake.animite.navigation.SharedContentKey
@@ -25,7 +24,6 @@ import com.imashnake.animite.navigation.SharedContentKey.Component.Image
 import com.imashnake.animite.navigation.SharedContentKey.Component.Page
 import com.imashnake.animite.navigation.SharedContentKey.Component.Text
 import com.imashnake.animite.profile.R
-import com.imashnake.animite.core.R as coreR
 
 /**
  * This can either be the anime tab or manga tab, it has a collection of lists for different
@@ -90,21 +88,18 @@ private fun UserMediaLists(
             MediaSmallRow(namedList.name, namedList.list) { item ->
                 with(sharedTransitionScope) {
                     val media = item as Media.Small
-                    MediaSmall(
+                    MediaCard(
                         image = media.coverImage,
                         label = media.title,
                         onClick = {
                             onNavigateToMediaItem(
                                 MediaPage(
                                     id = media.id,
-                                    // TODO: We can use the list's index instead.
                                     source = namedList.name.orEmpty(),
                                     mediaType = media.type.name,
                                 )
                             )
                         },
-                        imageHeight = dimensionResource(coreR.dimen.media_image_height),
-                        cardWidth = dimensionResource(coreR.dimen.media_card_width),
                         modifier = Modifier.sharedBounds(
                             rememberSharedContentState(
                                 SharedContentKey(


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Abstracts `MediaSmall` away from the rest of the app. This has a few advantages

- Callers don't need to manually specify width/height
- All areas are guaranteed to look the same, rather than expecting them to pass the same size in
- The funny size parameters are hidden from consumers
- Gets rid of a couple of dimen resources

**Summary of changes:**

1. Created MediaCard
2. Created CharacterCard
3. Migrated usages to new cards
4. Made MediaSmall internal

**Tested changes:**

App runs and same info is displayed as before

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
