### PR TITLE
Home Screen -> Fix Start Padding in Landscape Mode

### DIFF
--- a/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
@@ -88,7 +88,9 @@ import com.imashnake.animite.core.ui.shaders.etherealShader
 import com.imashnake.animite.media.MediaPage
 import com.imashnake.animite.navigation.SharedContentKey
 import com.imashnake.animite.navigation.SharedContentKey.Component.Card
+import com.imashnake.animite.navigation.SharedContentKey.Component.Image
 import com.imashnake.animite.navigation.SharedContentKey.Component.Page
+import com.imashnake.animite.navigation.SharedContentKey.Component.Text
 import com.materialkolor.ktx.hasEnoughContrast
 import com.imashnake.animite.media.R as mediaR
 import com.imashnake.animite.navigation.R as navigationR

--- a/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/imashnake/animite/features/home/HomeScreen.kt
@@ -88,9 +88,7 @@ import com.imashnake.animite.core.ui.shaders.etherealShader
 import com.imashnake.animite.media.MediaPage
 import com.imashnake.animite.navigation.SharedContentKey
 import com.imashnake.animite.navigation.SharedContentKey.Component.Card
-import com.imashnake.animite.navigation.SharedContentKey.Component.Image
 import com.imashnake.animite.navigation.SharedContentKey.Component.Page
-import com.imashnake.animite.navigation.SharedContentKey.Component.Text
 import com.materialkolor.ktx.hasEnoughContrast
 import com.imashnake.animite.media.R as mediaR
 import com.imashnake.animite.navigation.R as navigationR
@@ -113,6 +111,7 @@ fun HomeScreen(
             start = dimensionResource(navigationR.dimen.navigation_rail_width)
         )
     }
+    val insetAndNavigationPaddingValues = insetPaddingValues + navigationComponentPaddingValues
 
     val homeMediaType = rememberSaveable { mutableStateOf(MediaType.ANIME) }
     viewModel.setMediaType(homeMediaType.value)
@@ -217,8 +216,7 @@ fun HomeScreen(
                                     AnimatedContent(
                                         targetState = it,
                                         transitionSpec = {
-                                            fadeIn(tween(750))
-                                                .togetherWith(fadeOut(tween(750)))
+                                            fadeIn(tween(750)).togetherWith(fadeOut(tween(750)))
                                         },
                                         label = "animate_home_row"
                                     ) { mediaList ->
@@ -240,7 +238,7 @@ fun HomeScreen(
                                                 contentPadding = PaddingValues(
                                                     horizontal = LocalPaddings.current.large,
                                                     vertical = LocalPaddings.current.large / 2,
-                                                ) + insetPaddingValues.horizontalOnly
+                                                ) + insetAndNavigationPaddingValues.horizontalOnly
                                             )
                                         } else {
                                             Box(Modifier.fillMaxWidth())
@@ -252,8 +250,8 @@ fun HomeScreen(
                         contentPadding = PaddingValues(
                             top = LocalPaddings.current.large / 2,
                             bottom = LocalPaddings.current.large / 2 +
-                                    insetPaddingValues.calculateBottomPadding()
-                        ) + navigationComponentPaddingValues,
+                                    insetAndNavigationPaddingValues.calculateBottomPadding()
+                        ),
                         verticalArrangement = Arrangement.spacedBy(0.dp)
                     )
                 }


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Navigation rail padding was applied at a higher level.

**Summary of changes:**

1. Moved navigation rail padding to content padding of `HomeRow`.

**Tested changes:**

yuh

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
