### PR TITLE
Profile Screen -> Fix Loading on Initial Login

### DIFF
--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -58,7 +58,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil3.compose.AsyncImage
 import com.boswelja.markdown.material3.MarkdownDocument
 import com.boswelja.markdown.material3.m3TextStyles

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileViewModel.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -55,10 +56,14 @@ class ProfileViewModel @Inject constructor(
 
     val viewerAnimeLists = combine(
         flow = refreshTrigger.onStart { emit(Unit) },
-        flow2 = preferencesRepository.viewerId,
+        flow2 = preferencesRepository.viewerId.filterNotNull(),
         transform = ::Pair,
     ).flatMapLatest {
-        userRepository.fetchUserMediaList(it.second?.toIntOrNull(), MediaType.ANIME, useNetwork)
+        userRepository.fetchUserMediaList(
+            id = it.second.toIntOrNull(),
+            type = MediaType.MANGA,
+            useNetwork = useNetwork,
+        )
     }.asResource().stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(1000),
@@ -67,10 +72,14 @@ class ProfileViewModel @Inject constructor(
 
     val viewerMangaLists = combine(
         flow = refreshTrigger.onStart { emit(Unit) },
-        flow2 = preferencesRepository.viewerId,
+        flow2 = preferencesRepository.viewerId.filterNotNull(),
         transform = ::Pair,
     ).flatMapLatest {
-        userRepository.fetchUserMediaList(it.second?.toIntOrNull(), MediaType.MANGA, useNetwork)
+        userRepository.fetchUserMediaList(
+            id = it.second.toIntOrNull(),
+            type = MediaType.MANGA,
+            useNetwork = useNetwork,
+        )
     }.asResource().stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(1000),


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Because of emitting an initially null `viewerId`, the anime and manga list requests fail and the profile screen defaults to the progress indicator on logging in for the first time.

**Summary of changes:**

1. Add `filterNotNull()` on `viewerId` to prevent null emissions.
2. Use `combine` instead of the ext function since it's nicer to look at.
3. Fix deprecation: `import androidx.hilt.navigation.compose.hiltViewModel` -> `import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel`

**Tested changes:**

`ProfileScreen` seems to load without issues now.

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
