### PR TITLE
Profile Screen -> Collapse and Refresh

### DIFF
--- a/banner/src/main/kotlin/com/imashnake/animite/banner/BannerLayout.kt
+++ b/banner/src/main/kotlin/com/imashnake/animite/banner/BannerLayout.kt
@@ -3,6 +3,7 @@ package com.imashnake.animite.banner
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -70,8 +71,11 @@ fun BannerLayout(
 
 @Composable
 fun NestedScrollBannerLayout(
-    banner: @Composable (Float, Modifier) -> Unit,
+    banner: @Composable BoxScope.(Float, Modifier) -> Unit,
+    bannerElevatedContent: @Composable BoxScope.(Float) -> Unit,
     content: @Composable ColumnScope.() -> Unit,
+    isExpanded: Boolean,
+    setIsExpanded: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     maxBannerHeight: Dp = dimensionResource(R.dimen.banner_height),
     contentPadding: PaddingValues = PaddingValues(),
@@ -83,29 +87,29 @@ fun NestedScrollBannerLayout(
     val statusBarHeight = with(density) { WindowInsets.statusBars.getTop(density).toDp() }
     val minBannerHeight = statusBarHeight + LocalPaddings.current.large
 
-    val nestedScrollConnection = remember {
+    val nestedScrollConnection = remember(isExpanded) {
         object : NestedScrollConnection {
             override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-                // Calculate the change in image size based on scroll delta
-                val delta = available.y / 5
-                val newImageSize = bannerHeight + delta.dp
-                val previousImageSize = bannerHeight
+                val newSize = bannerHeight + (available.y / 5).dp
+                if (isExpanded) {
+                    bannerHeight = newSize.coerceIn(minBannerHeight, maxBannerHeight)
+                    ratio = (bannerHeight - minBannerHeight) / (maxBannerHeight - minBannerHeight)
 
-                // Constrain the image size within the allowed bounds
-                bannerHeight = newImageSize.coerceIn(minBannerHeight, maxBannerHeight)
-                val consumed = bannerHeight - previousImageSize
+                    if (ratio == 0f) setIsExpanded(false)
+                }
 
-                // Calculate the scale for the image
-                ratio = (bannerHeight - minBannerHeight) / (maxBannerHeight - minBannerHeight)
-
-                // Return the consumed scroll amount
-                return Offset(0f, consumed.value)
+                return Offset.Zero
             }
         }
     }
 
     Box(modifier.nestedScroll(nestedScrollConnection)) {
-
+        banner(
+            ratio,
+            Modifier
+                .height(bannerHeight)
+                .fillMaxWidth()
+        )
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -114,11 +118,6 @@ fun NestedScrollBannerLayout(
                 .padding(contentPadding),
             verticalArrangement = verticalArrangement
         ) { content() }
-        banner(
-            ratio,
-            Modifier
-                .height(bannerHeight)
-                .fillMaxWidth()
-        )
+        bannerElevatedContent(ratio)
     }
 }

--- a/banner/src/main/kotlin/com/imashnake/animite/banner/BannerLayout.kt
+++ b/banner/src/main/kotlin/com/imashnake/animite/banner/BannerLayout.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -28,7 +27,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastCoerceIn
 import com.imashnake.animite.core.ui.LocalPaddings
 
 /**
@@ -74,30 +73,60 @@ fun NestedScrollBannerLayout(
     banner: @Composable BoxScope.(Float, Modifier) -> Unit,
     bannerElevatedContent: @Composable BoxScope.(Float) -> Unit,
     content: @Composable ColumnScope.() -> Unit,
-    isExpanded: Boolean,
-    setIsExpanded: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     maxBannerHeight: Dp = dimensionResource(R.dimen.banner_height),
     contentPadding: PaddingValues = PaddingValues(),
     verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(LocalPaddings.current.large)
 ) {
-    var bannerHeight by remember { mutableStateOf(maxBannerHeight) }
-    var ratio by remember { mutableFloatStateOf(1f) }
     val density = LocalDensity.current
+    var bannerHeightPx by remember { mutableFloatStateOf(with(density) { maxBannerHeight.toPx() }) }
+    var ratio by remember { mutableFloatStateOf(1f) }
     val statusBarHeight = with(density) { WindowInsets.statusBars.getTop(density).toDp() }
-    val minBannerHeight = statusBarHeight + LocalPaddings.current.large
+    val minBannerHeightPx = with(density) { (statusBarHeight + LocalPaddings.current.large).toPx() }
+    val maxBannerHeightPx = with(density) { maxBannerHeight.toPx() }
 
-    val nestedScrollConnection = remember(isExpanded) {
+    // Copied from TopAppBar.ExitUntilCollapsedScrollBehavior
+    val nestedScrollConnection = remember {
         object : NestedScrollConnection {
             override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-                val newSize = bannerHeight + (available.y / 5).dp
-                if (isExpanded) {
-                    bannerHeight = newSize.coerceIn(minBannerHeight, maxBannerHeight)
-                    ratio = (bannerHeight - minBannerHeight) / (maxBannerHeight - minBannerHeight)
+                // Don't intercept if scrolling down.
+                if (available.y > 0f) return Offset.Zero
 
-                    if (ratio == 0f) setIsExpanded(false)
+                val prevBannerHeight = bannerHeightPx
+                bannerHeightPx = (bannerHeightPx + available.y).fastCoerceIn(minBannerHeightPx, maxBannerHeightPx)
+                ratio = (bannerHeightPx - minBannerHeightPx) / (maxBannerHeightPx - minBannerHeightPx)
+                return if (prevBannerHeight != bannerHeightPx) {
+                    // We're in the middle of top app bar collapse or expand.
+                    // Consume only the scroll on the Y axis.
+                    available.copy(x = 0f)
+                } else {
+                    Offset.Zero
+                }
+            }
+
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource,
+            ): Offset {
+                if (available.y < 0f || consumed.y < 0f) {
+                    // When scrolling up, just update the state's height offset.
+                    val oldBannerHeight = bannerHeightPx
+                    bannerHeightPx = (bannerHeightPx + consumed.y).fastCoerceIn(minBannerHeightPx, maxBannerHeightPx)
+                    ratio = (bannerHeightPx - minBannerHeightPx) / (maxBannerHeightPx - minBannerHeightPx)
+
+                    return Offset(0f, bannerHeightPx - oldBannerHeight)
                 }
 
+                if (available.y > 0f) {
+                    // Adjust the height offset in case the consumed delta Y is less than what was
+                    // recorded as available delta Y in the pre-scroll.
+                    val oldBannerHeight = bannerHeightPx
+                    bannerHeightPx = (bannerHeightPx + available.y).fastCoerceIn(minBannerHeightPx, maxBannerHeightPx)
+                    ratio = (bannerHeightPx - minBannerHeightPx) / (maxBannerHeightPx - minBannerHeightPx)
+
+                    return Offset(0f, bannerHeightPx - oldBannerHeight)
+                }
                 return Offset.Zero
             }
         }
@@ -107,13 +136,13 @@ fun NestedScrollBannerLayout(
         banner(
             ratio,
             Modifier
-                .height(bannerHeight)
+                .height(with(density) { bannerHeightPx.toDp() })
                 .fillMaxWidth()
         )
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = bannerHeight)
+                .padding(top = with(density) { bannerHeightPx.toDp() })
                 .background(MaterialTheme.colorScheme.background)
                 .padding(contentPadding),
             verticalArrangement = verticalArrangement

--- a/banner/src/main/kotlin/com/imashnake/animite/banner/BannerLayout.kt
+++ b/banner/src/main/kotlin/com/imashnake/animite/banner/BannerLayout.kt
@@ -6,15 +6,28 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.imashnake.animite.core.ui.LocalPaddings
 
 /**
@@ -52,5 +65,60 @@ fun BannerLayout(
                 .padding(contentPadding),
             verticalArrangement = verticalArrangement
         ) { content() }
+    }
+}
+
+@Composable
+fun NestedScrollBannerLayout(
+    banner: @Composable (Float, Modifier) -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    maxBannerHeight: Dp = dimensionResource(R.dimen.banner_height),
+    contentPadding: PaddingValues = PaddingValues(),
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(LocalPaddings.current.large)
+) {
+    var bannerHeight by remember { mutableStateOf(maxBannerHeight) }
+    var ratio by remember { mutableFloatStateOf(1f) }
+    val density = LocalDensity.current
+    val statusBarHeight = with(density) { WindowInsets.statusBars.getTop(density).toDp() }
+    val minBannerHeight = statusBarHeight + LocalPaddings.current.large
+
+    val nestedScrollConnection = remember {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                // Calculate the change in image size based on scroll delta
+                val delta = available.y / 5
+                val newImageSize = bannerHeight + delta.dp
+                val previousImageSize = bannerHeight
+
+                // Constrain the image size within the allowed bounds
+                bannerHeight = newImageSize.coerceIn(minBannerHeight, maxBannerHeight)
+                val consumed = bannerHeight - previousImageSize
+
+                // Calculate the scale for the image
+                ratio = (bannerHeight - minBannerHeight) / (maxBannerHeight - minBannerHeight)
+
+                // Return the consumed scroll amount
+                return Offset(0f, consumed.value)
+            }
+        }
+    }
+
+    Box(modifier.nestedScroll(nestedScrollConnection)) {
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = bannerHeight)
+                .background(MaterialTheme.colorScheme.background)
+                .padding(contentPadding),
+            verticalArrangement = verticalArrangement
+        ) { content() }
+        banner(
+            ratio,
+            Modifier
+                .height(bannerHeight)
+                .fillMaxWidth()
+        )
     }
 }

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.displayCutout
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.plus
@@ -37,7 +36,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ExitToApp
 import androidx.compose.material.icons.rounded.MoreVert
-import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenuItem
@@ -51,6 +49,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -148,80 +148,88 @@ fun ProfileScreen(
                     LaunchedEffect(avatar) {
                         if (viewerAvatar != avatar) viewModel.saveViewerAvatar(avatar)
                     }
-                    NestedScrollBannerLayout(
-                        banner = { ratio, modifier ->
-                            Box {
-                                AsyncImage(
-                                    model = crossfadeModel(banner),
-                                    contentDescription = null,
-                                    alpha = ratio,
-                                    modifier = modifier,
-                                    contentScale = ContentScale.Crop
-                                )
-                                AsyncImage(
-                                    model = crossfadeModel(avatar),
-                                    contentDescription = "Avatar",
-                                    modifier = Modifier
-                                        .align(Alignment.BottomStart)
-                                        .padding(start = LocalPaddings.current.large)
-                                        .padding(allPaddingValues.horizontalOnly)
-                                        .wrapContentSize()
-                                        .maxHeight(100.dp)
-                                        .clip(
-                                            RoundedCornerShape(
-                                                topStart = LocalPaddings.current.small,
-                                                topEnd = LocalPaddings.current.small,
-                                            )
-                                        )
-                                        .graphicsLayer { alpha = ratio },
-                                )
-                            }
-                        },
-                        bannerElevatedContent = { ratio ->
-                            SettingsAndMore(
-                                onNavigateToSettings = onNavigateToSettings,
-                                logOut = { isLogOutDialogShown = true },
-                                refresh = { viewModel.refresh { isDropdownExpanded = false } },
-                                expanded = isDropdownExpanded,
-                                setExpanded = { isDropdownExpanded = it },
-                                modifier = Modifier
-                                    .align(Alignment.TopEnd)
-                                    .padding(allPaddingValues.copy(bottom = 0.dp))
-                                    .padding(
-                                        start = LocalPaddings.current.large,
-                                        bottom = LocalPaddings.current.large,
-                                        end = LocalPaddings.current.large
+
+                    var isRefreshing by remember { mutableStateOf(false) }
+                    val pullToRefreshState = rememberPullToRefreshState()
+                    PullToRefreshBox(
+                        isRefreshing = isRefreshing,
+                        onRefresh = { viewModel.refresh { isRefreshing = it } },
+                        state = pullToRefreshState,
+                    ) {
+                        NestedScrollBannerLayout(
+                            banner = { ratio, modifier ->
+                                Box {
+                                    AsyncImage(
+                                        model = crossfadeModel(banner),
+                                        contentDescription = null,
+                                        alpha = ratio,
+                                        modifier = modifier,
+                                        contentScale = ContentScale.Crop
                                     )
-                                    .padding(top = LocalPaddings.current.large * ratio)
-                            )
-                        },
-                        content = {
-                            Column(verticalArrangement = Arrangement.spacedBy(LocalPaddings.current.ultraTiny)) {
-                                Column(
-                                    modifier = Modifier
-                                        .padding(horizontal = LocalPaddings.current.large)
-                                        .padding(allPaddingValues.horizontalOnly)
-                                ) {
-                                    Text(
-                                        text = name,
-                                        color = MaterialTheme.colorScheme.onBackground,
-                                        style = MaterialTheme.typography.titleLarge,
-                                        overflow = TextOverflow.Ellipsis,
+                                    AsyncImage(
+                                        model = crossfadeModel(avatar),
+                                        contentDescription = "Avatar",
+                                        modifier = Modifier
+                                            .align(Alignment.BottomStart)
+                                            .padding(start = LocalPaddings.current.large)
+                                            .padding(allPaddingValues.horizontalOnly)
+                                            .wrapContentSize()
+                                            .maxHeight(100.dp)
+                                            .clip(
+                                                RoundedCornerShape(
+                                                    topStart = LocalPaddings.current.small,
+                                                    topEnd = LocalPaddings.current.small,
+                                                )
+                                            )
+                                            .graphicsLayer { alpha = ratio },
                                     )
                                 }
-                                UserTabs(
-                                    user = this@run,
-                                    animeCollection = viewerAnimeLists.data,
-                                    mangaCollection = viewerMangaLists.data,
-                                    onNavigateToMediaItem = onNavigateToMediaItem,
-                                    sharedTransitionScope = sharedTransitionScope,
-                                    animatedVisibilityScope = animatedVisibilityScope,
-                                    contentPadding = navigationComponentPaddingValues + insetPaddingValues,
+                            },
+                            bannerElevatedContent = { ratio ->
+                                SettingsAndMore(
+                                    onNavigateToSettings = onNavigateToSettings,
+                                    logOut = { isLogOutDialogShown = true },
+                                    expanded = isDropdownExpanded,
+                                    setExpanded = { isDropdownExpanded = it },
+                                    modifier = Modifier
+                                        .align(Alignment.TopEnd)
+                                        .padding(allPaddingValues.copy(bottom = 0.dp))
+                                        .padding(
+                                            start = LocalPaddings.current.large,
+                                            bottom = LocalPaddings.current.large,
+                                            end = LocalPaddings.current.large
+                                        )
+                                        .padding(top = LocalPaddings.current.large * ratio)
                                 )
-                            }
-                        },
-                        contentPadding = PaddingValues(top = LocalPaddings.current.large / 2)
-                    )
+                            },
+                            content = {
+                                Column(verticalArrangement = Arrangement.spacedBy(LocalPaddings.current.ultraTiny)) {
+                                    Column(
+                                        modifier = Modifier
+                                            .padding(horizontal = LocalPaddings.current.large)
+                                            .padding(allPaddingValues.horizontalOnly)
+                                    ) {
+                                        Text(
+                                            text = name,
+                                            color = MaterialTheme.colorScheme.onBackground,
+                                            style = MaterialTheme.typography.titleLarge,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                    }
+                                    UserTabs(
+                                        user = this@run,
+                                        animeCollection = viewerAnimeLists.data,
+                                        mangaCollection = viewerMangaLists.data,
+                                        onNavigateToMediaItem = onNavigateToMediaItem,
+                                        sharedTransitionScope = sharedTransitionScope,
+                                        animatedVisibilityScope = animatedVisibilityScope,
+                                        contentPadding = navigationComponentPaddingValues + insetPaddingValues,
+                                    )
+                                }
+                            },
+                            contentPadding = PaddingValues(top = LocalPaddings.current.large / 2)
+                        )
+                    }
                 }
                 else -> ProgressIndicatorScreen(Modifier.padding(allPaddingValues))
             }
@@ -282,7 +290,6 @@ private fun SettingsAndMore(
     expanded: Boolean,
     setExpanded: (Boolean) -> Unit,
     logOut: () -> Unit,
-    refresh: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val cascadeState = rememberCascadeState()
@@ -330,22 +337,6 @@ private fun SettingsAndMore(
                 ),
                 offset = DpOffset(x = 0.dp, y = LocalPaddings.current.tiny),
             ) {
-                // TODO: This is horrible UX, use nested scroll <-> pull to refresh.
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.refresh)) },
-                    leadingIcon = {
-                        Icon(
-                            imageVector = Icons.Rounded.Refresh,
-                            contentDescription = stringResource(R.string.refresh),
-                        )
-                    },
-                    colors = MenuDefaults.itemColors(
-                        leadingIconColor = MaterialTheme.colorScheme.primary
-                    ),
-                    onClick = refresh,
-                    contentPadding = PaddingValues(LocalPaddings.current.medium)
-                )
-
                 // TODO: The material3 DropdownMenuItem doesn't respect layout direction padding.
                 //  Figure out why/create an issue. saket-cascade works just fine.
                 DropdownMenuItem(

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.plus
@@ -135,8 +136,6 @@ fun ProfileScreen(
     var isLogOutDialogShown by remember { mutableStateOf(false) }
     var isDropdownExpanded by remember { mutableStateOf(false) }
 
-    var isBannerExpanded by remember { mutableStateOf(true) }
-
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -150,8 +149,6 @@ fun ProfileScreen(
                         if (viewerAvatar != avatar) viewModel.saveViewerAvatar(avatar)
                     }
                     NestedScrollBannerLayout(
-                        isExpanded = isBannerExpanded,
-                        setIsExpanded = { isBannerExpanded = it },
                         banner = { ratio, modifier ->
                             Box {
                                 AsyncImage(

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
@@ -73,13 +74,15 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastCoerceIn
 import androidx.compose.ui.util.fastForEachIndexed
+import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil3.compose.AsyncImage
 import com.boswelja.markdown.material3.MarkdownDocument
 import com.boswelja.markdown.material3.m3TextStyles
 import com.imashnake.animite.api.anilist.sanitize.profile.User
-import com.imashnake.animite.banner.BannerLayout
+import com.imashnake.animite.banner.NestedScrollBannerLayout
 import com.imashnake.animite.core.resource.Resource
 import com.imashnake.animite.core.ui.LocalPaddings
 import com.imashnake.animite.core.ui.component.ProgressIndicatorScreen
@@ -147,12 +150,13 @@ fun ProfileScreen(
                     LaunchedEffect(avatar) {
                         if (viewerAvatar != avatar) viewModel.saveViewerAvatar(avatar)
                     }
-                    BannerLayout(
-                        banner = { modifier ->
+                    NestedScrollBannerLayout(
+                        banner = { ratio, modifier ->
                             Box {
                                 AsyncImage(
                                     model = crossfadeModel(banner),
                                     contentDescription = null,
+                                    alpha = ratio,
                                     modifier = modifier,
                                     contentScale = ContentScale.Crop
                                 )
@@ -170,19 +174,31 @@ fun ProfileScreen(
                                                 topStart = LocalPaddings.current.small,
                                                 topEnd = LocalPaddings.current.small,
                                             )
-                                        ),
-                                )
-                                SettingsAndMore(
-                                    onNavigateToSettings = onNavigateToSettings,
-                                    logOut = { isLogOutDialogShown = true },
-                                    refresh = { viewModel.refresh { isDropdownExpanded = false } },
-                                    expanded = isDropdownExpanded,
-                                    setExpanded = { isDropdownExpanded = it },
-                                    modifier = Modifier
-                                        .align(Alignment.TopEnd)
-                                        .padding(allPaddingValues.copy(bottom = 0.dp)),
+                                        ).graphicsLayer {
+                                            transformOrigin = TransformOrigin(0.5f, 1f)
+                                            alpha = ratio
+                                            scaleX = ratio.fastCoerceIn(0.5f, 1f)
+                                            scaleY = ratio.fastCoerceIn(0.5f, 1f)
+                                        },
                                 )
                             }
+                            SettingsAndMore(
+                                onNavigateToSettings = onNavigateToSettings,
+                                logOut = { isLogOutDialogShown = true },
+                                refresh = { viewModel.refresh { isDropdownExpanded = false } },
+                                expanded = isDropdownExpanded,
+                                setExpanded = { isDropdownExpanded = it },
+                                modifier = Modifier
+                                    .align(Alignment.TopEnd)
+                                    .padding(allPaddingValues.copy(bottom = 0.dp))
+                                    .padding(
+                                        start = LocalPaddings.current.large,
+                                        bottom = LocalPaddings.current.large,
+                                        end = LocalPaddings.current.large
+                                    )
+                                    .padding(top = LocalPaddings.current.large * ratio)
+                                    .zIndex(5f),
+                            )
                         },
                         content = {
                             Column(verticalArrangement = Arrangement.spacedBy(LocalPaddings.current.ultraTiny)) {
@@ -283,7 +299,7 @@ private fun SettingsAndMore(
     Row(
         horizontalArrangement = Arrangement.spacedBy(LocalPaddings.current.small),
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.padding(LocalPaddings.current.large)
+        modifier = modifier
     ) {
         SettingsIcon(onNavigateToSettings = onNavigateToSettings)
 

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -63,7 +63,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
@@ -74,9 +73,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.fastCoerceIn
 import androidx.compose.ui.util.fastForEachIndexed
-import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil3.compose.AsyncImage
 import com.boswelja.markdown.material3.MarkdownDocument
@@ -138,6 +135,8 @@ fun ProfileScreen(
     var isLogOutDialogShown by remember { mutableStateOf(false) }
     var isDropdownExpanded by remember { mutableStateOf(false) }
 
+    var isBannerExpanded by remember { mutableStateOf(true) }
+
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
@@ -151,6 +150,8 @@ fun ProfileScreen(
                         if (viewerAvatar != avatar) viewModel.saveViewerAvatar(avatar)
                     }
                     NestedScrollBannerLayout(
+                        isExpanded = isBannerExpanded,
+                        setIsExpanded = { isBannerExpanded = it },
                         banner = { ratio, modifier ->
                             Box {
                                 AsyncImage(
@@ -174,14 +175,12 @@ fun ProfileScreen(
                                                 topStart = LocalPaddings.current.small,
                                                 topEnd = LocalPaddings.current.small,
                                             )
-                                        ).graphicsLayer {
-                                            transformOrigin = TransformOrigin(0.5f, 1f)
-                                            alpha = ratio
-                                            scaleX = ratio.fastCoerceIn(0.5f, 1f)
-                                            scaleY = ratio.fastCoerceIn(0.5f, 1f)
-                                        },
+                                        )
+                                        .graphicsLayer { alpha = ratio },
                                 )
                             }
+                        },
+                        bannerElevatedContent = { ratio ->
                             SettingsAndMore(
                                 onNavigateToSettings = onNavigateToSettings,
                                 logOut = { isLogOutDialogShown = true },
@@ -197,7 +196,6 @@ fun ProfileScreen(
                                         end = LocalPaddings.current.large
                                     )
                                     .padding(top = LocalPaddings.current.large * ratio)
-                                    .zIndex(5f),
                             )
                         },
                         content = {

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileViewModel.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileViewModel.kt
@@ -14,6 +14,7 @@ import com.imashnake.animite.navigation.ProfileRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
@@ -101,11 +102,13 @@ class ProfileViewModel @Inject constructor(
         }
     }
 
-    fun refresh(onRefresh: () -> Unit) = viewModelScope.launch {
-        onRefresh()
+    fun refresh(setIsRefreshing: (Boolean) -> Unit) = viewModelScope.launch {
+        setIsRefreshing(true)
         useNetwork = true
         refreshTrigger.emit(Unit)
+        delay(1500L)
         useNetwork = false
+        setIsRefreshing(false)
     }
 
     val viewerAvatar = preferencesRepository.viewerAvatar

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/About.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/About.kt
@@ -53,6 +53,7 @@ fun AboutTab(
 
     Column(
         modifier = modifier
+            .fillMaxHeight()
             .verticalScroll(scrollState)
             .padding(contentPadding),
         verticalArrangement = Arrangement.spacedBy(LocalPaddings.current.medium)

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Favourites.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Favourites.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -75,7 +76,7 @@ private fun UserFavouriteLists(
 
     Column(
         modifier = modifier
-            .fillMaxWidth()
+            .fillMaxSize()
             .verticalScroll(scrollState)
             .padding(contentPadding.verticalOnly),
         verticalArrangement = Arrangement.spacedBy(LocalPaddings.current.large),

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Media.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/tabs/Media.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -85,7 +86,7 @@ private fun UserMediaLists(
 
     Column(
         modifier =  modifier
-            .fillMaxWidth()
+            .fillMaxSize()
             .verticalScroll(scrollState)
             .padding(contentPadding.verticalOnly),
         verticalArrangement = Arrangement.spacedBy(LocalPaddings.current.large),


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Collapse the banner (new layout) and pull to refresh instead of menu refresh.

**Summary of changes:**

1. Create new `NestedScrollBannerLayout` to collapse the banner like an AppBar.
2. Remove refresh menu option for pull to refresh.

**Tested changes:**
ye

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
