### PR TITLE
Profile Screen -> Manual Collapse for Nested Scroll Banner

### DIFF
--- a/banner/src/main/kotlin/com/imashnake/animite/banner/BannerLayout.kt
+++ b/banner/src/main/kotlin/com/imashnake/animite/banner/BannerLayout.kt
@@ -1,5 +1,6 @@
 package com.imashnake.animite.banner
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
@@ -30,6 +32,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.util.fastCoerceIn
 import com.imashnake.animite.core.ui.LocalPaddings
+import com.imashnake.animite.core.ui.ext.thenIf
 
 /**
  * Most screens and pages follow a banner-style layout in Animite.
@@ -74,6 +77,7 @@ fun NestedScrollBannerLayout(
     banner: @Composable BoxScope.(Float, Modifier) -> Unit,
     bannerElevatedContent: @Composable BoxScope.(Float) -> Unit,
     content: @Composable ColumnScope.() -> Unit,
+    isExpanded: Boolean,
     modifier: Modifier = Modifier,
     maxBannerHeight: Dp = dimensionResource(R.dimen.banner_height),
     contentPadding: PaddingValues = PaddingValues(),
@@ -85,6 +89,16 @@ fun NestedScrollBannerLayout(
     val maxBannerHeightPx = with(density) { maxBannerHeight.toPx() }
     var bannerHeightPx by remember { mutableFloatStateOf(maxBannerHeightPx) }
     var ratio by remember { mutableFloatStateOf(1f) }
+
+    LaunchedEffect(isExpanded) {
+        if (isExpanded) {
+            ratio = 1f
+            bannerHeightPx = maxBannerHeightPx
+        } else {
+            ratio = 0f
+            bannerHeightPx = minBannerHeightPx
+        }
+    }
 
     // Copied from TopAppBar.ExitUntilCollapsedScrollBehavior
     val nestedScrollConnection = remember {
@@ -133,17 +147,18 @@ fun NestedScrollBannerLayout(
         }
     }
 
-    Box(modifier.nestedScroll(nestedScrollConnection)) {
+    Box(modifier.thenIf(condition = isExpanded) { nestedScroll(nestedScrollConnection) }) {
+        val bannerHeight by animateFloatAsState(bannerHeightPx)
         banner(
             ratio,
             Modifier
-                .height(with(density) { bannerHeightPx.toDp() })
+                .height(with(density) { bannerHeight.toDp() })
                 .fillMaxWidth()
         )
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = with(density) { bannerHeightPx.toDp() })
+                .padding(top = with(density) { bannerHeight.toDp() })
                 .background(contentBackgroundColor)
                 .padding(contentPadding),
             verticalArrangement = verticalArrangement

--- a/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
+++ b/profile/src/main/kotlin/com/imashnake/animite/profile/ProfileScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
@@ -66,9 +67,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -182,18 +185,22 @@ fun ProfileScreen(
 
                         var isRefreshing by remember { mutableStateOf(false) }
                         val pullToRefreshState = rememberPullToRefreshState()
+
+                        var isBannerExpanded by remember { mutableStateOf(true) }
                         PullToRefreshBox(
                             isRefreshing = isRefreshing,
                             onRefresh = { viewModel.refresh { isRefreshing = it } },
                             state = pullToRefreshState,
                         ) {
                             NestedScrollBannerLayout(
+                                isExpanded = isBannerExpanded,
                                 banner = { ratio, modifier ->
+                                    val animRatio by animateFloatAsState(ratio)
                                     Box(Modifier.background(MaterialTheme.colorScheme.surfaceContainer)) {
                                         AsyncImage(
                                             model = crossfadeModel(banner),
                                             contentDescription = null,
-                                            alpha = 1.2f * ratio - 0.2f,
+                                            alpha = 1.2f * animRatio - 0.2f,
                                             modifier = modifier,
                                             contentScale = ContentScale.Crop
                                         )
@@ -212,12 +219,15 @@ fun ProfileScreen(
                                                         topEnd = LocalPaddings.current.small,
                                                     )
                                                 )
-                                                .graphicsLayer { alpha = 1.5f * ratio - 0.5f },
+                                                .graphicsLayer { alpha = 1.5f * animRatio - 0.5f },
                                         )
                                     }
                                 },
                                 bannerElevatedContent = { ratio ->
+                                    val animRatio by animateFloatAsState(ratio)
                                     SettingsAndMore(
+                                        isBannerExpanded = isBannerExpanded,
+                                        onBannerExpanded = { isBannerExpanded = !isBannerExpanded },
                                         onNavigateToSettings = onNavigateToSettings,
                                         logOut = { isLogOutDialogShown = true },
                                         expanded = isDropdownExpanded,
@@ -230,7 +240,7 @@ fun ProfileScreen(
                                                 bottom = LocalPaddings.current.large,
                                                 end = LocalPaddings.current.large
                                             )
-                                            .padding(top = LocalPaddings.current.large * ratio)
+                                            .padding(top = LocalPaddings.current.large * animRatio)
                                     )
                                 },
                                 content = {
@@ -341,6 +351,8 @@ fun ProfileScreen(
 
 @Composable
 private fun SettingsAndMore(
+    isBannerExpanded: Boolean,
+    onBannerExpanded: () -> Unit,
     onNavigateToSettings: (SettingsPage) -> Unit,
     expanded: Boolean,
     setExpanded: (Boolean) -> Unit,
@@ -358,6 +370,8 @@ private fun SettingsAndMore(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
     ) {
+        BannerHeightToggle(isBannerExpanded, onBannerExpanded)
+
         SettingsIcon(onNavigateToSettings = onNavigateToSettings)
 
         Box {
@@ -440,6 +454,35 @@ fun SettingsIcon(
             tint = MaterialTheme.colorScheme.primary,
             modifier = Modifier
                 .clickable { onNavigateToSettings(SettingsPage) }
+                .padding(LocalPaddings.current.small)
+                .size(16.dp)
+                .graphicsLayer { rotationZ = angle }
+        )
+    }
+}
+
+@Composable
+fun BannerHeightToggle(
+    isExpanded: Boolean,
+    onToggleBannerHeight: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val haptic = LocalHapticFeedback.current
+    val angle by animateFloatAsState(if (isExpanded) 0f else 180f)
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = CircleShape,
+        modifier = modifier,
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.banner_toggle),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .clickable {
+                    haptic.performHapticFeedback(HapticFeedbackType.ContextClick)
+                    onToggleBannerHeight()
+                }
                 .padding(LocalPaddings.current.small)
                 .size(16.dp)
                 .graphicsLayer { rotationZ = angle }

--- a/profile/src/main/res/drawable/banner_toggle.xml
+++ b/profile/src/main/res/drawable/banner_toggle.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M368,460h224q14,0 19,-12t-5,-22l-98,-98q-12,-12 -28,-12t-28,12l-98,98q-10,10 -5,22t19,12ZM200,840q-33,0 -56.5,-23.5T120,760v-560q0,-33 23.5,-56.5T200,120h560q33,0 56.5,23.5T840,200v560q0,33 -23.5,56.5T760,840L200,840ZM200,640v120h560v-120L200,640ZM200,560h560v-360L200,200v360ZM200,640v120,-120Z"
+      android:fillColor="#e3e3e3"/>
+</vector>


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

Added a toggle to manually show/hide the banner forever. There are now two states:
- Banner is shown with nested scroll as before.
- Banner is hidden forever (use the same button to back to ^).

**Summary of changes:**

1. Add toggle button.
2. Animate values and somehow make scroll smoother.
3. Show/hide banner.

**Tested changes:**

ya

[comment]: # (THANK YOU! ♡\(灬♥ ◡ ♥灬\))
