### PR TITLE
fix: add Referer header to AniList requests

### DIFF
--- a/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/Clients.kt
+++ b/api/anilist/src/main/kotlin/com/imashnake/animite/api/anilist/Clients.kt
@@ -20,13 +20,38 @@ private val SqlCacheFactory
     get() = SqlNormalizedCacheFactory("apollo.db")
 
 /**
+ * Adds the Referer header to every AniList API request.
+ *
+ * AniList currently requires this header for requests from third-party
+ * clients. Without it, otherwise valid API requests may be rejected with
+ * an HTTP 403 response.
+ *
+ * This behavior is not part of the documented API contract and may change
+ * in the future. Keeping the header handling in a dedicated interceptor
+ * makes it easy to update or remove if AniList changes its requirements.
+ */
+private val aniListRefererInterceptor = object : HttpInterceptor {
+    override suspend fun intercept(
+        request: HttpRequest,
+        chain: HttpInterceptorChain
+    ): HttpResponse {
+        return chain.proceed(
+            request.newBuilder()
+                .addHeader("Referer", "https://anilist.co/")
+                .build()
+        )
+    }
+}
+
+/**
  * Creates an [ApolloClient] configured to access AniList APIs.
  */
- fun createApolloHttpClient(): ApolloClient {
+fun createApolloHttpClient(): ApolloClient {
     val cacheFactory = MemoryCacheFactory.chain(SqlCacheFactory)
     return ApolloClient.Builder()
         .dispatcher(Dispatchers.IO)
         .serverUrl(BaseUrl)
+        .addHttpInterceptor(aniListRefererInterceptor)
         .addHttpInterceptor(LoggingInterceptor(LoggingInterceptor.Level.BODY))
         .cache(cacheFactory)
         .build()
@@ -58,6 +83,7 @@ fun createAuthenticatedApolloHttpClient(
         .dispatcher(Dispatchers.IO)
         .serverUrl(BaseUrl)
         .addHttpInterceptor(httpInterceptor)
+        .addHttpInterceptor(aniListRefererInterceptor)
         .addHttpInterceptor(LoggingInterceptor(LoggingInterceptor.Level.BODY))
         .cache(cacheFactory)
         .build()


### PR DESCRIPTION
[comment]: # (Replace [ ] with [x].)
- [x] Read [`CONTRIBUTING.md`](https://github.com/imashnake0/Animite/blob/be53ba4561c8ff20f588fb348965f208e301b6b8/CONTRIBUTING.md).

[comment]: # (Replace this comment with a description. Include links to relevant documentation.)

**Summary of changes:**

1. Added an HTTP interceptor that adds the `Referer` header to AniList API requests.
2. Applied the interceptor to both authenticated and unauthenticated Apollo clients.
3. Kept the header handling isolated so it can be easily updated or removed if AniList changes its API requirements.

**Tested changes:**

Verified the AniList API requests using Hoppscotch with and without the `Referer` header. Requests without the header were rejected with HTTP 403, while requests with `Referer: https://anilist.co/` returned successfully. Also verified the change with the application's Apollo client.